### PR TITLE
fix: correct tailwind class in global card style

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,7 +13,7 @@ body {
 }
 
 .card {
-  @apply bg-white border border-slate-200 rounded-2xl shadow-soft;
+  @apply bg-white border border-slate-200 rounded-2xl shadow-card;
 }
 
 .btn {


### PR DESCRIPTION
## Summary
- fix global card style by using existing `shadow-card` class instead of undefined `shadow-soft`

## Testing
- `npm run build 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ae7d4c9684832f86ebcec7c8ede162