### PR TITLE
Ensure greeting detection only triggers on full greetings

### DIFF
--- a/app/api/answer/route.ts
+++ b/app/api/answer/route.ts
@@ -18,8 +18,11 @@ Keep it tight and neutral.
 `;
 
 function isGreeting(text: string) {
-  const s = text.toLowerCase().trim();
-  return ['hi','hello','hey','namaste','good morning','good afternoon','good evening'].some(w => s.startsWith(w));
+  const s = text
+    .toLowerCase()
+    .replace(/^[\s\p{P}\p{S}]+|[\s\p{P}\p{S}]+$/gu, '')
+    .trim();
+  return ['hi','hello','hey','namaste','good morning','good afternoon','good evening'].includes(s);
 }
 
 const DISCLAIMER = '⚠️ Informational only — not a substitute for advice from a licensed advocate.';


### PR DESCRIPTION
## Summary
- Require `isGreeting` to match the full input after trimming punctuation, preventing partial greeting matches.

## Testing
- `node - <<'NODE' ...` verifying `isGreeting` returns false for "Hi, draft a rent agreement" and intent detection proceeds.
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7eb29ef4832f927e9b15ee98cc3a