### PR TITLE
Add dark/light mode toggle and theme styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+npm-debug.log*
+.pnpm-debug.log*

--- a/app/globals.css
+++ b/app/globals.css
@@ -6,24 +6,28 @@
   color-scheme: light;
 }
 
+:root.dark {
+  color-scheme: dark;
+}
+
 body {
-  @apply bg-white text-slate-800;
+  @apply bg-white text-slate-800 dark:bg-zinc-900 dark:text-zinc-100;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 .card {
-  @apply bg-white border border-slate-200 rounded-2xl shadow-soft;
+  @apply bg-white border border-slate-200 rounded-2xl shadow-soft dark:bg-zinc-800 dark:border-zinc-700;
 }
 
 .btn {
-  @apply inline-flex items-center justify-center rounded-xl border border-slate-300 px-4 py-2 text-sm hover:bg-slate-50 disabled:opacity-50;
+  @apply inline-flex items-center justify-center rounded-xl border border-slate-300 px-4 py-2 text-sm hover:bg-slate-50 disabled:opacity-50 dark:border-zinc-600 dark:hover:bg-zinc-700;
 }
 
 .input {
-  @apply w-full rounded-xl border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500;
+  @apply w-full rounded-xl border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500 dark:bg-zinc-800 dark:border-zinc-700 dark:text-zinc-100;
 }
 
 .prose-custom {
-  @apply prose prose-slate max-w-none;
+  @apply prose prose-slate max-w-none dark:prose-invert;
 }

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,41 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { Moon, Sun } from 'lucide-react';
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (stored === 'dark' || (!stored && prefersDark)) {
+      setTheme('dark');
+      document.documentElement.classList.add('dark');
+    } else {
+      setTheme('light');
+      document.documentElement.classList.remove('dark');
+    }
+  }, []);
+
+  const toggle = () => {
+    const next = theme === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+    if (next === 'dark') {
+      document.documentElement.classList.add('dark');
+      window.localStorage.setItem('theme', 'dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+      window.localStorage.setItem('theme', 'light');
+    }
+  };
+
+  return (
+    <button
+      aria-label="Toggle dark mode"
+      className="p-2 rounded hover:bg-zinc-100 dark:hover:bg-zinc-800"
+      onClick={toggle}
+    >
+      {theme === 'dark' ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+    </button>
+  );
+}

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import Link from 'next/link';
+import ThemeToggle from './ThemeToggle';
 
 type Props = {
   title?: string;
@@ -10,23 +11,24 @@ type Props = {
 
 export default function TopBar({ title = 'LexLens' }: Props) {
   return (
-    <header className="w-full border-b bg-white/70 backdrop-blur supports-[backdrop-filter]:bg-white/60">
+    <header className="w-full border-b border-zinc-200 bg-white/70 dark:bg-zinc-900/70 backdrop-blur supports-[backdrop-filter]:bg-white/60 supports-[backdrop-filter]:dark:bg-zinc-900/60 dark:border-zinc-700">
       <div className="mx-auto max-w-6xl px-4 h-12 flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <Link href="/" className="font-semibold text-zinc-800">
+          <Link href="/" className="font-semibold text-zinc-800 dark:text-zinc-100">
             {title}
           </Link>
-          <nav className="hidden sm:flex items-center gap-4 text-sm text-zinc-600">
-            <Link href="/search" className="hover:text-black">Search</Link>
-            <Link href="/library" className="hover:text-black">Library</Link>
-            <Link href="/settings" className="hover:text-black">Settings</Link>
+          <nav className="hidden sm:flex items-center gap-4 text-sm text-zinc-600 dark:text-zinc-400">
+            <Link href="/search" className="hover:text-black dark:hover:text-white">Search</Link>
+            <Link href="/library" className="hover:text-black dark:hover:text-white">Library</Link>
+            <Link href="/settings" className="hover:text-black dark:hover:text-white">Settings</Link>
           </nav>
         </div>
 
         <div className="flex items-center gap-2">
+          <ThemeToggle />
           <Link
             href="/upgrade"
-            className="text-xs sm:text-sm border rounded px-3 py-1 hover:bg-zinc-50"
+            className="text-xs sm:text-sm border border-zinc-200 dark:border-zinc-700 rounded px-3 py-1 hover:bg-zinc-50 dark:hover:bg-zinc-700"
           >
             Upgrade
           </Link>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: 'class',
   content: [
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
## Summary
- add theme toggle button to switch between dark and light modes
- enable Tailwind class-based dark mode and update global styles
- style top bar and common components for dark theme

## Testing
- `npm test` *(fails: Missing script "test" in package.json)*
- `npm run lint` *(interactive prompt, no lint results)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7f034ba0832f9d96a17fbac3bdec