### PR TITLE
test: add context extraction tests

### DIFF
--- a/lib/memory.test.ts
+++ b/lib/memory.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { extractContextBits } from './memory';
+
+describe('extractContextBits', () => {
+  it('detects rent agreement intent', () => {
+    const bits = extractContextBits('Need a rent agreement for my house.');
+    expect(bits).toMatchObject({ intent: 'rent_agreement' });
+  });
+
+  it('extracts city and state', () => {
+    const bits = extractContextBits('I need documents in mumbai maharashtra');
+    expect(bits).toMatchObject({ city: 'Mumbai', state: 'Maharashtra' });
+  });
+
+  it('detects property type', () => {
+    const bits = extractContextBits('Looking to rent out an apartment.');
+    expect(bits).toMatchObject({ property: 'apartment' });
+  });
+
+  it('returns empty object for unrelated text', () => {
+    const bits = extractContextBits('How are you today?');
+    expect(bits).toEqual({});
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev -p 3000",
     "build": "next build",
     "start": "next start -p 3000",
-    "lint": "next lint || true"
+    "lint": "next lint || true",
+    "test": "vitest run"
   },
   "dependencies": {
     "@mozilla/readability": "0.5.0",
@@ -32,6 +33,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "postcss": "8.4.41",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "vitest": "^1.6.0"
   }
 }


### PR DESCRIPTION
## Summary
- add vitest config and test script
- cover rent agreement, location and property extraction

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae80952f0c832f8eb445b94f5c36f6