### PR TITLE
Append citizen-mode disclaimer and centralize text

### DIFF
--- a/app/api/answer/route.ts
+++ b/app/api/answer/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
 import { getContext, updateContext, extractContextBits, summarizeContext, clearContext } from '@/lib/memory';
+import { DISCLAIMER } from '@/lib/constants';
 
 const SYSTEM_PROMPT_CITIZEN = `
 You are a friendly legal explainer for regular citizens.
 Use simple words, short paragraphs, step-by-step explanations, avoid legalese.
-Add a short "Not legal advice." line at the end.
 If the question is vague, ask 1–2 quick clarifying questions first (ONLY if those details are not provided in the context below).
 Always respect and use the provided CONTEXT if present, and do not ask again for what is already given.
 `;
@@ -22,7 +22,6 @@ function isGreeting(text: string) {
   return ['hi','hello','hey','namaste','good morning','good afternoon','good evening'].some(w => s.startsWith(w));
 }
 
-const DISCLAIMER = '⚠️ Informational only — not a substitute for advice from a licensed advocate.';
 
 // env
 const PROVIDER = (process.env.AI_PROVIDER || 'gemini').toLowerCase();
@@ -176,7 +175,7 @@ export async function POST(req: Request) {
       answer = await callOpenAI(key, OPENAI_MODEL, system, q, ctxSummary, docBits);
     }
 
-    if (mode === 'citizen') answer += `\n\n${'⚠️ Informational only — not a substitute for advice from a licensed advocate.'}`;
+    if (mode === 'citizen') answer += `\n\n${DISCLAIMER}`;
     return NextResponse.json({ answer, context: getContext(ip), sources: [] });
   } catch (err: any) {
     console.error('[answer route error]', err?.message || err, err?.stack);

--- a/app/home-client.tsx
+++ b/app/home-client.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import ModeToggle from '@/components/ModeToggle';
 import ChatWindow from '@/components/ChatWindow';
+import { DISCLAIMER } from '@/lib/constants';
 
 export default function HomeClient() {
   const [mode, setMode] = useState<'citizen'|'lawyer'>('citizen');
@@ -31,9 +32,9 @@ export default function HomeClient() {
               {q}
             </button>
           ))}
-          <div className="text-[11px] text-slate-500 px-1">
-            Informational only — not legal advice.
-          </div>
+          {mode === 'citizen' && (
+            <div className="text-[11px] text-slate-500 px-1">{DISCLAIMER}</div>
+          )}
         </div>
       </div>
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,1 @@
+export const DISCLAIMER = '⚠️ Not legal advice.';

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -2,7 +2,6 @@
 export const SYSTEM_PROMPT_CITIZEN = `
 You are a friendly legal explainer for regular citizens.
 Style: simple words, short paragraphs, step-by-step, no legalese.
-Add a brief "Not legal advice" line at the end.
 If the question is vague or incomplete, ask 1–2 short clarifying questions before answering.
 Keep answers within 8–12 sentences unless asked for depth.
 `;
@@ -40,4 +39,3 @@ export function looksVague(text: string) {
     || (/help|law|legal|case|section|advise|advice|problem/.test(s) && !/\d{3,4}|article|section|ipc|crpc|contract|gst|divorce|bail|notice|rti|consumer|writ|fir/.test(s));
 }
 
-export const DISCLAIMER = "⚠️ Informational only — not a substitute for advice from a licensed advocate.";


### PR DESCRIPTION
## Summary
- Centralize "⚠️ Not legal advice." in a shared constant
- Automatically append the disclaimer only in citizen mode responses
- Display the disclaimer on the home page only for citizen mode
- Simplify citizen prompt by removing redundant disclaimer instruction

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ae80c659c8832f8c59d40446657edf