### PR TITLE
Sanitize question input and document length limit

### DIFF
--- a/app/api/answer/README.md
+++ b/app/api/answer/README.md
@@ -1,0 +1,7 @@
+# Answer API
+
+POST requests should include a JSON body with a `q` field containing the
+question. The server trims and normalizes this value, rejecting empty inputs or
+any question longer than **500 characters**. If the limit changes, update this
+file and the `MAX_Q_LEN` constant in `route.ts`.
+


### PR DESCRIPTION
## Summary
- Normalize and trim `q` before use, rejecting empty or over-500-character inputs
- Strip control/special tokens that could break prompt format
- Document question length limit in new API route README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ae80c4cb38832f874fbac26b2e1a74