### PR TITLE
Fix data rights wording in privacy policy

### DIFF
--- a/app/legal/privacy/page.tsx
+++ b/app/legal/privacy/page.tsx
@@ -2,7 +2,7 @@ export default function PrivacyPage() {
   return (
     <div className="prose max-w-3xl">
       <h1>Privacy Policy</h1>
-      <p>We collect minimal data to operate the service: account details, queries, and usage telemetry. We keep query logs for no more than 90 days and support data-rights requests. For the DPDP-compliant full policy, replace this text with your customized policy from the canvas.</p>
+      <p>We collect minimal data to operate the service: account details, queries, and usage telemetry. We keep query logs for no more than 90 days and support data rights requests. For the DPDP-compliant full policy, replace this text with your customized policy from the canvas.</p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- clarify privacy policy wording by replacing "data-rights requests" with "data rights requests"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ae82a9e2f8832f9396d4dbf43e0a6a