### PR TITLE
chore: fail Docker build on npm install errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:20-alpine AS deps
 WORKDIR /app
 COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* .npmrc* ./
-RUN npm i --prefer-offline --no-audit --progress=false || true
+RUN npm install
 
 FROM node:20-alpine AS builder
 WORKDIR /app


### PR DESCRIPTION
## Summary
- replace `npm i` wrapper in Dockerfile with straight `npm install` so installs fail instead of being masked

## Testing
- `docker build . -t legal4:latest` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae85cb0078832f941fa66ffe042c2f