### PR TITLE
Add legal expertise profiles and profile-aware controller

### DIFF
--- a/chat/controller.py
+++ b/chat/controller.py
@@ -1,0 +1,62 @@
+"""Chat controller with domain-specific expertise profiles."""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+import yaml
+
+# Directory containing expertise profiles
+EXPERTISE_DIR = os.path.join(os.path.dirname(__file__), "..", "config", "expertise")
+
+# Keyword mapping for domain detection
+_KEYWORD_MAP: Dict[str, list[str]] = {
+    "criminal": ["crime", "ipc", "penal", "murder", "bail"],
+    "civil": ["contract", "tort", "property", "injunction"],
+    "intellectual_property": ["copyright", "trademark", "patent", "ip"],
+    "tax": ["tax", "gst", "income tax", "assessment"],
+}
+
+
+def detect_domain(text: str) -> Optional[str]:
+    """Detect the legal domain from input text."""
+    text = text.lower()
+    for domain, keywords in _KEYWORD_MAP.items():
+        if any(keyword in text for keyword in keywords):
+            return domain
+    return None
+
+
+def load_profile(domain: Optional[str] = None, *, text: str = "") -> Dict[str, Any]:
+    """Load an expertise profile by domain or detect from text."""
+    if domain is None:
+        domain = detect_domain(text)
+    if domain is None:
+        return {}
+
+    path = os.path.join(EXPERTISE_DIR, f"{domain}.yml")
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        return {}
+
+
+class ChatController:
+    """Simple chat controller that manages expertise profiles."""
+
+    def __init__(self, domain: Optional[str] = None) -> None:
+        self.domain = domain
+        self.profile: Dict[str, Any] = {}
+
+    def configure(self, *, domain: Optional[str] = None, text: str = "") -> None:
+        """Configure the controller using an explicit domain or detected keywords."""
+        self.domain = domain or detect_domain(text)
+        if self.domain:
+            self.profile = load_profile(self.domain)
+        else:
+            self.profile = {}
+
+    def get_profile(self) -> Dict[str, Any]:
+        """Return the currently loaded expertise profile."""
+        return self.profile

--- a/config/expertise/civil.yml
+++ b/config/expertise/civil.yml
@@ -1,0 +1,11 @@
+name: civil
+statutes:
+  - Code of Civil Procedure, 1908
+  - Specific Relief Act, 1963
+terminology:
+  - injunction
+  - damages
+  - tort
+reasoning_patterns:
+  - Determine cause of action and legal remedy.
+  - Balance equities and apply precedent.

--- a/config/expertise/criminal.yml
+++ b/config/expertise/criminal.yml
@@ -1,0 +1,11 @@
+name: criminal
+statutes:
+  - Indian Penal Code, 1860
+  - Code of Criminal Procedure, 1973
+terminology:
+  - FIR
+  - bail
+  - mens rea
+reasoning_patterns:
+  - Evaluate actus reus and mens rea.
+  - Consider admissibility of evidence and burden of proof.

--- a/config/expertise/intellectual_property.yml
+++ b/config/expertise/intellectual_property.yml
@@ -1,0 +1,11 @@
+name: intellectual_property
+statutes:
+  - Patents Act, 1970
+  - Trade Marks Act, 1999
+terminology:
+  - prior art
+  - infringement
+  - passing off
+reasoning_patterns:
+  - Assess originality and registrability.
+  - Compare marks or inventions for substantial similarity.

--- a/config/expertise/tax.yml
+++ b/config/expertise/tax.yml
@@ -1,0 +1,11 @@
+name: tax
+statutes:
+  - Income Tax Act, 1961
+  - Goods and Services Tax Act, 2017
+terminology:
+  - assessment year
+  - input tax credit
+  - depreciation
+reasoning_patterns:
+  - Analyze taxable event and applicable exemptions.
+  - Interpret fiscal statutes strictly while favoring taxpayer if ambiguity.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,26 @@
+# User Guide
+
+The chat controller can tailor answers using domain-specific expertise profiles. Profiles live in `config/expertise/` and describe key statutes, common terminology, and typical reasoning patterns for each area of law.
+
+## Selecting a profile
+
+Choose a domain explicitly when configuring the controller:
+
+```python
+from chat.controller import ChatController
+
+controller = ChatController()
+controller.configure(domain="criminal")
+print(controller.get_profile()["statutes"])
+```
+
+## Automatic detection
+
+If no domain is provided, the controller inspects the prompt and loads the matching profile when keywords are found:
+
+```python
+controller.configure(text="What is the punishment for theft under IPC?")
+print(controller.domain)  # -> 'criminal'
+```
+
+Call `configure` again with a different domain or text to switch profiles at any time.


### PR DESCRIPTION
## Summary
- add YAML expertise profiles for criminal, civil, intellectual property, and tax law
- introduce chat controller that loads expertise profiles explicitly or via keyword detection
- document how to switch expertise profiles and use automatic detection

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(requires interactive setup; cancelled)*
- `python -m py_compile chat/controller.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae85b520f0832fa6d3bfd007b91291