### PR TITLE
Add contextual prompt templates and runtime selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+__pycache__/

--- a/chat/__init__.py
+++ b/chat/__init__.py
@@ -1,0 +1,3 @@
+"""Chat logic package."""
+
+__all__ = []

--- a/chat/controller.py
+++ b/chat/controller.py
@@ -1,0 +1,43 @@
+"""Chat controller selecting contextual prompt templates."""
+
+from dataclasses import dataclass, field
+from typing import List
+
+from prompts.contextual import build_template
+
+
+@dataclass
+class SessionMetadata:
+    """Metadata describing a chat session.
+
+    Attributes
+    ----------
+    history:
+        Previous conversation turns.
+    role:
+        Declared role of the interacting user (``user``, ``lawyer`` or ``admin``).
+    jurisdiction:
+        Jurisdiction to consider when generating responses.
+    """
+
+    history: List[str] = field(default_factory=list)
+    role: str = "user"
+    jurisdiction: str = "OTHER"
+
+
+def select_template(session: SessionMetadata) -> str:
+    """Select a contextual prompt for the given ``session``.
+
+    Parameters
+    ----------
+    session:
+        Session metadata describing the active conversation.
+
+    Returns
+    -------
+    str
+        A context sensitive template string.
+    """
+
+    return build_template(session.history, session.role, session.jurisdiction)
+

--- a/prompts/__init__.py
+++ b/prompts/__init__.py
@@ -1,0 +1,3 @@
+"""Prompt template package."""
+
+__all__ = []

--- a/prompts/contextual.py
+++ b/prompts/contextual.py
@@ -1,0 +1,52 @@
+"""Dynamic prompt templates for chat interactions.
+
+This module provides utilities for constructing prompt text that adapts
+based on previous conversation history, the role of the user interacting
+with the system, and the jurisdiction in which the query is framed.
+"""
+
+from typing import List, Sequence
+
+ROLE_TEMPLATES = {
+    "user": "Provide a concise, helpful response.",
+    "lawyer": "Offer detailed legal analysis tailored for professionals.",
+    "admin": "Return high level administrative guidance.",
+}
+
+JURISDICTION_TEMPLATES = {
+    "US": "Reference United States law.",
+    "EU": "Reference European Union law.",
+    "OTHER": "Reference general international legal principles.",
+}
+
+def build_template(history: Sequence[str] | None, role: str, jurisdiction: str) -> str:
+    """Compose a context aware template string.
+
+    Parameters
+    ----------
+    history:
+        Ordered collection of previous conversation turns. When present,
+        they are embedded in the template to preserve context.
+    role:
+        The role of the current user. The wording changes when the role is
+        recognised (``user``, ``lawyer`` or ``admin``). Unrecognised roles
+        fall back to ``user`` semantics.
+    jurisdiction:
+        Jurisdiction of the question. Currently recognised values are
+        ``US`` and ``EU``. Any other value falls back to a generic
+        international wording.
+
+    Returns
+    -------
+    str
+        Combined template string.
+    """
+    parts: List[str] = []
+    if history:
+        parts.append("Conversation so far: " + " | ".join(history))
+
+    parts.append(ROLE_TEMPLATES.get(role, ROLE_TEMPLATES["user"]))
+    parts.append(JURISDICTION_TEMPLATES.get(jurisdiction, JURISDICTION_TEMPLATES["OTHER"]))
+
+    return " ".join(parts)
+

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,34 @@
+"""Integration tests for contextual prompt templates."""
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+
+from chat.controller import SessionMetadata, select_template
+
+
+def test_user_us_with_history():
+    session = SessionMetadata(
+        history=["What is the statute of limitations?", "It depends."],
+        role="user",
+        jurisdiction="US",
+    )
+    template = select_template(session)
+    assert "Conversation so far" in template
+    assert "United States law" in template
+    assert "concise" in template
+
+
+def test_lawyer_eu_no_history():
+    session = SessionMetadata(history=[], role="lawyer", jurisdiction="EU")
+    template = select_template(session)
+    assert "European Union law" in template
+    assert "detailed legal analysis" in template
+    assert "Conversation so far" not in template
+
+
+def test_admin_unknown_jurisdiction():
+    session = SessionMetadata(history=["previous"], role="admin", jurisdiction="BR")
+    template = select_template(session)
+    assert "administrative guidance" in template
+    assert "international legal principles" in template
+


### PR DESCRIPTION
## Summary
- add dynamic templates that consider conversation history, user role, and jurisdiction
- allow chat controller to choose templates based on session metadata
- test template switching across user, lawyer, and admin scenarios

## Testing
- `pytest tests/test_prompts.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae85af7ee4832f8cf7fca39739deda