### PR TITLE
Default to OpenAI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ pnpm dev   # then open http://localhost:3000
 ```
 
 ## Environment
-- `OPENAI_API_KEY` (optional): for real answers. Without it you'll see a demo answer with source links.
+- `AI_PROVIDER` (optional): `openai` (default) or `gemini`.
+- `OPENAI_API_KEY` (optional): for OpenAI answers. Without it you'll see a demo answer with source links.
+- `GEMINI_API_KEY` (required if `AI_PROVIDER=gemini`): for Google Gemini answers.
 
 ## Roadmap hooks (not included yet)
 - Retrieval pipeline (India Code / Gazette / SC / HCs) with hybrid search and RAG
@@ -43,7 +45,11 @@ pnpm dev   # then open http://localhost:3000
 
 Example `.env.local`:
 ```
+AI_PROVIDER=openai
 OPENAI_API_KEY=sk-...
+# For Gemini instead:
+# AI_PROVIDER=gemini
+# GEMINI_API_KEY=...
 BING_API_KEY=...
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 # PREFER_HINDI=1

--- a/app/api/answer/route.ts
+++ b/app/api/answer/route.ts
@@ -25,7 +25,8 @@ function isGreeting(text: string) {
 const DISCLAIMER = '⚠️ Informational only — not a substitute for advice from a licensed advocate.';
 
 // env
-const PROVIDER = (process.env.AI_PROVIDER || 'gemini').toLowerCase();
+// Default to OpenAI to avoid failing when only OPENAI_API_KEY is set.
+const PROVIDER = (process.env.AI_PROVIDER || 'openai').toLowerCase();
 const GEMINI_MODEL = process.env.GEMINI_MODEL || 'gemini-1.5-flash';
 const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4o';
 
@@ -165,7 +166,7 @@ export async function POST(req: Request) {
         );
       }
       answer = await callGemini(key, GEMINI_MODEL, system, q, ctxSummary, docBits);
-    } else {
+    } else if (PROVIDER === 'openai') {
       const key = process.env.OPENAI_API_KEY;
       if (!key) {
         return NextResponse.json(
@@ -174,6 +175,11 @@ export async function POST(req: Request) {
         );
       }
       answer = await callOpenAI(key, OPENAI_MODEL, system, q, ctxSummary, docBits);
+    } else {
+      return NextResponse.json(
+        { answer: `❌ Unknown AI provider "${PROVIDER}". Set AI_PROVIDER to 'openai' or 'gemini'.` },
+        { status: 500 }
+      );
     }
 
     if (mode === 'citizen') answer += `\n\n${'⚠️ Informational only — not a substitute for advice from a licensed advocate.'}`;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,4 @@ services:
       - "3000:3000"
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - AI_PROVIDER=openai


### PR DESCRIPTION
## Summary
- default AI provider to OpenAI to avoid missing Gemini key
- clarify provider handling and add unknown-provider guard
- document AI_PROVIDER and GEMINI_API_KEY usage, include AI_PROVIDER in docker-compose

## Testing
- `npm install --registry=https://registry.npmjs.org` *(fails: 403 Forbidden for @mozilla/readability)*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae85c93b1c832fad84c58bc461c4d2