### PR TITLE
feat: configure AI provider in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,4 @@ services:
       - "3000:3000"
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - AI_PROVIDER=openai


### PR DESCRIPTION
## Summary
- add `AI_PROVIDER=openai` to web service environment

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run build` *(fails: PostCSS `shadow-soft` class missing)*
- `docker compose down` *(fails: command not found)*
- `curl -s -S -D - http://localhost:3000/api/debug` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68ae85cd9dbc832fb31c216ab7df2c55