### PR TITLE
feat: add configurable web search providers

### DIFF
--- a/app/api/websearch/route.ts
+++ b/app/api/websearch/route.ts
@@ -1,42 +1,90 @@
 import { NextResponse } from 'next/server';
 
-const DOMAINS = [
-  'indiacode.nic.in',
-  'egazette.nic.in',
-  'main.sci.gov.in',
-  'sci.gov.in',
-  'highcourt',
-  'gov.in'
+interface SearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+const DOMAIN_FILTER =
+  'site:indiacode.nic.in OR site:egazette.nic.in OR site:sci.gov.in OR (site:gov.in "High Court")';
+
+const FALLBACK_RESULTS: SearchResult[] = [
+  {
+    title: 'India Code — Search',
+    url: 'https://www.indiacode.nic.in/',
+    snippet: 'Official repository of Acts and subordinate legislation.'
+  },
+  {
+    title: 'e-Gazette of India',
+    url: 'https://egazette.nic.in/',
+    snippet: 'Official Gazette notifications.'
+  },
+  {
+    title: 'Supreme Court of India — Judgments',
+    url: 'https://main.sci.gov.in/judgments',
+    snippet: 'Official judgments.'
+  }
 ];
 
-export async function POST(req: Request) {
-  const { query } = await req.json();
+async function searchBing(query: string): Promise<SearchResult[]> {
   const key = process.env.BING_API_KEY;
-  if (!key) {
-    // Fallback static suggestions
-    return NextResponse.json({
-      results: [
-        { title: 'India Code — Search', url: 'https://www.indiacode.nic.in/', snippet: 'Official repository of Acts and subordinate legislation.' },
-        { title: 'e-Gazette of India', url: 'https://egazette.nic.in/', snippet: 'Official Gazette notifications.' },
-        { title: 'Supreme Court of India — Judgments', url: 'https://main.sci.gov.in/judgments', snippet: 'Official judgments.' }
-      ]
-    });
-  }
+  if (!key) return [];
 
-  // Use Bing Web Search v7
-  const domainFilter = 'site:indiacode.nic.in OR site:egazette.nic.in OR site:sci.gov.in OR (site:gov.in "High Court")';
-  const q = `${query} ${domainFilter}`;
-  const url = `https://api.bing.microsoft.com/v7.0/search?q=${encodeURIComponent(q)}&mkt=en-IN&count=10&responseFilter=Webpages`;
-
-  const r = await fetch(url, { headers: { 'Ocp-Apim-Subscription-Key': key } });
-  if (!r.ok) {
-    return NextResponse.json({ results: [] });
-  }
+  const q = `${query} ${DOMAIN_FILTER}`;
+  const url =
+    `https://api.bing.microsoft.com/v7.0/search?q=${encodeURIComponent(q)}&mkt=en-IN&count=10&responseFilter=Webpages`;
+  const r = await fetch(url, {
+    headers: { 'Ocp-Apim-Subscription-Key': key }
+  });
+  if (!r.ok) return [];
   const data = await r.json();
-  const results = (data.webPages?.value || []).map((x: any) => ({
+  return (data.webPages?.value || []).map((x: any) => ({
     title: x.name,
     url: x.url,
     snippet: x.snippet
   }));
+}
+
+async function searchGoogle(query: string): Promise<SearchResult[]> {
+  const key = process.env.GOOGLE_API_KEY;
+  const cx = process.env.GOOGLE_CX; // Custom Search Engine ID
+  if (!key || !cx) return [];
+
+  const q = `${query} ${DOMAIN_FILTER}`;
+  const url =
+    `https://www.googleapis.com/customsearch/v1?q=${encodeURIComponent(q)}&key=${key}&cx=${cx}`;
+  const r = await fetch(url);
+  if (!r.ok) return [];
+  const data = await r.json();
+  return (data.items || []).map((x: any) => ({
+    title: x.title,
+    url: x.link,
+    snippet: x.snippet
+  }));
+}
+
+function fallbackResults(): SearchResult[] {
+  return FALLBACK_RESULTS;
+}
+
+export async function POST(req: Request) {
+  const { query, provider } = await req.json();
+  const selectedProvider =
+    (provider || process.env.WEBSEARCH_PROVIDER || 'bing').toLowerCase();
+
+  let results: SearchResult[] = [];
+  if (selectedProvider === 'google') {
+    results = await searchGoogle(query);
+  } else {
+    // default to Bing
+    results = await searchBing(query);
+  }
+
+  if (!results.length) {
+    results = fallbackResults();
+  }
+
   return NextResponse.json({ results });
 }
+


### PR DESCRIPTION
## Summary
- refactor web search route with provider-specific helpers
- support selecting Bing or Google via request param or WEBSEARCH_PROVIDER env var
- implement Google Custom Search API with key handling and fallback results

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden while fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ae899f0b08832fac2698df4822c14d