### PR TITLE
Add AI provider configuration for docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,5 @@ services:
     ports:
       - "3000:3000"
     environment:
+      - AI_PROVIDER=openai
       - OPENAI_API_KEY=${OPENAI_API_KEY}


### PR DESCRIPTION
## Summary
- add AI provider configuration to docker-compose

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: required interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8a2c5c6c832f91180967768c9252