### PR TITLE
Default to OpenAI provider and clarify config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ pnpm dev   # then open http://localhost:3000
 ```
 
 ## Environment
-- `OPENAI_API_KEY` (optional): for real answers. Without it you'll see a demo answer with source links.
+- `AI_PROVIDER` (optional): `openai` (default) or `gemini`.
+- `OPENAI_API_KEY` (required if `AI_PROVIDER=openai`): for real answers. Without it you'll see a demo answer with source links.
+- `GEMINI_API_KEY` (required if `AI_PROVIDER=gemini`): Google Gemini key.
 
 ## Roadmap hooks (not included yet)
 - Retrieval pipeline (India Code / Gazette / SC / HCs) with hybrid search and RAG

--- a/app/api/answer/route.ts
+++ b/app/api/answer/route.ts
@@ -25,7 +25,7 @@ function isGreeting(text: string) {
 const DISCLAIMER = '⚠️ Informational only — not a substitute for advice from a licensed advocate.';
 
 // env
-const PROVIDER = (process.env.AI_PROVIDER || 'gemini').toLowerCase();
+const PROVIDER = (process.env.AI_PROVIDER || 'openai').toLowerCase();
 const GEMINI_MODEL = process.env.GEMINI_MODEL || 'gemini-1.5-flash';
 const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4o';
 
@@ -165,7 +165,7 @@ export async function POST(req: Request) {
         );
       }
       answer = await callGemini(key, GEMINI_MODEL, system, q, ctxSummary, docBits);
-    } else {
+    } else if (PROVIDER === 'openai') {
       const key = process.env.OPENAI_API_KEY;
       if (!key) {
         return NextResponse.json(
@@ -174,6 +174,11 @@ export async function POST(req: Request) {
         );
       }
       answer = await callOpenAI(key, OPENAI_MODEL, system, q, ctxSummary, docBits);
+    } else {
+      return NextResponse.json(
+        { answer: '❌ Unsupported AI_PROVIDER. Use "openai" or "gemini".' },
+        { status: 500 }
+      );
     }
 
     if (mode === 'citizen') answer += `\n\n${'⚠️ Informational only — not a substitute for advice from a licensed advocate.'}`;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,4 @@ services:
       - "3000:3000"
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - AI_PROVIDER=${AI_PROVIDER:-openai}


### PR DESCRIPTION
## Summary
- default API provider to OpenAI and guard against unsupported providers
- document `AI_PROVIDER` along with required OpenAI/Gemini keys
- include `AI_PROVIDER` in docker-compose for OpenAI-only deployments

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run build` *(fails: `shadow-soft` class does not exist in globals.css)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8a2305cc832f9327173bc93458e6