### PR TITLE
feat: add soft shadow variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.next/

--- a/app/globals.css
+++ b/app/globals.css
@@ -13,6 +13,7 @@ body {
 }
 
 .card {
+  /* Card container with soft shadow */
   @apply bg-white border border-slate-200 rounded-2xl shadow-soft;
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,7 +21,7 @@ const config: Config = {
         "2xl": "1rem"
       },
       boxShadow: {
-        card: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)"
+        soft: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)"
       }
     }
   },


### PR DESCRIPTION
## Summary
- rename custom `boxShadow` key to `soft`
- document soft shadow usage in global card style
- add gitignore for dependencies and build output

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ae8de4f250832f9c9b257757c30de5