### PR TITLE
fix: apply defined card shadow utility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,7 +13,7 @@ body {
 }
 
 .card {
-  @apply bg-white border border-slate-200 rounded-2xl shadow-soft;
+  @apply bg-white border border-slate-200 rounded-2xl shadow-card;
 }
 
 .btn {
@@ -27,3 +27,4 @@ body {
 .prose-custom {
   @apply prose prose-slate max-w-none;
 }
+


### PR DESCRIPTION
## Summary
- use existing `shadow-card` utility in `.card` style

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae930ba4c0832f8607512e5697d30b