### PR TITLE
fix: use defined card shadow class

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,7 +13,7 @@ body {
 }
 
 .card {
-  @apply bg-white border border-slate-200 rounded-2xl shadow-soft;
+  @apply bg-white border border-slate-200 rounded-2xl shadow-card;
 }
 
 .btn {


### PR DESCRIPTION
## Summary
- replace undefined `shadow-soft` utility with existing `shadow-card`

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae94aa7908832f83621a640354acda