### PR TITLE
Rename card box shadow utility to soft

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,7 +21,7 @@ const config: Config = {
         "2xl": "1rem"
       },
       boxShadow: {
-        card: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)"
+        soft: "0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04)"
       }
     }
   },


### PR DESCRIPTION
## Summary
- rename custom box shadow key from `card` to `soft`
- ensure `.card` style applies `shadow-soft`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae93f551b8832f8d863da81feeec80