### PR TITLE
chore: update Data Rights case in privacy page

### DIFF
--- a/app/legal/privacy/page.tsx
+++ b/app/legal/privacy/page.tsx
@@ -2,7 +2,7 @@ export default function PrivacyPage() {
   return (
     <div className="prose max-w-3xl">
       <h1>Privacy Policy</h1>
-      <p>We collect minimal data to operate the service: account details, queries, and usage telemetry. We keep query logs for no more than 90 days and support data-rights requests. For the DPDP-compliant full policy, replace this text with your customized policy from the canvas.</p>
+      <p>We collect minimal data to operate the service: account details, queries, and usage telemetry. We keep query logs for no more than 90 days and support Data rights requests. For the DPDP-compliant full policy, replace this text with your customized policy from the canvas.</p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- update Data Rights to Data rights on privacy policy page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: prompts for ESLint configuration)
- `npm run build` (fails: CSS class `shadow-soft` does not exist)


------
https://chatgpt.com/codex/tasks/task_e_68ae94c1632c832fbace0045765ba42c