### PR TITLE
feat: integrate web retrieval pipeline with sources panel

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,7 @@
+# Example environment variables
+# Add your keys and redeploy
+
+OPENAI_API_KEY=
+BING_API_KEY=
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+# PREFER_HINDI=1

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,7 @@
 {
-  "version": 2
+  "version": 2,
+  "env": {
+    "BING_API_KEY": "@bing_api_key",
+    "NEXT_PUBLIC_BASE_URL": "@next_public_base_url"
+  }
 }


### PR DESCRIPTION
## Summary
- trigger web search and scraping before answering to supply context and sources
- show a Searching… indicator and render retrieved source links beneath replies
- add environment variable templates and deploy config for Bing search

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt; aborted)*
- `npm run build` *(fails: shadow-soft class missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae964623c4832fbaee7820a1e4a1ff