### PR TITLE
feat: enhance web search filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,30 @@ BING_API_KEY=...
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 # PREFER_HINDI=1
 ```
+
+## Web search API
+
+`POST /api/websearch` accepts:
+
+- `query` – the search terms (string)
+- `materialType` – optional, one of `case_law` or `research`. Determines which
+  trusted domains are searched (e.g., `case_law` includes `indiankanoon.org`
+  and High Courts; `research` includes law journals and repositories).
+
+The response is:
+
+```json
+{
+  "results": [
+    {
+      "title": "string",
+      "url": "string",
+      "snippet": "string",
+      "score": 0
+    }
+  ]
+}
+```
+
+`score` is a basic relevance score combining domain priority and keyword
+matches; results are returned in descending order.

--- a/app/api/websearch/route.ts
+++ b/app/api/websearch/route.ts
@@ -1,31 +1,73 @@
 import { NextResponse } from 'next/server';
 
-const DOMAINS = [
-  'indiacode.nic.in',
-  'egazette.nic.in',
-  'main.sci.gov.in',
-  'sci.gov.in',
-  'highcourt',
-  'gov.in'
-];
+// Domain sets for different material types. These are intentionally small and
+// focused on reliable, legal sources.
+const DOMAINS: Record<string, string[]> = {
+  case_law: [
+    'indiankanoon.org',
+    'main.sci.gov.in',
+    'sci.gov.in',
+    // High Courts often have their own domains; "highcourt" is used as a
+    // contains filter below.
+    'highcourt'
+  ],
+  research: [
+    'indiacode.nic.in',
+    'egazette.nic.in',
+    'lawcommissionofindia.nic.in',
+    // A couple of academic journal hosts
+    'academic.oup.com',
+    'journals.sagepub.com'
+  ],
+  // Fallback/general mix of trusted repositories
+  default: [
+    'indiacode.nic.in',
+    'egazette.nic.in',
+    'sci.gov.in',
+    'indiankanoon.org',
+    'gov.in'
+  ]
+};
+
+function buildDomainFilter(type: string | undefined) {
+  const list = DOMAINS[type as keyof typeof DOMAINS] || DOMAINS.default;
+  return list
+    .map((d) => (d === 'highcourt' ? '(site:gov.in "High Court")' : `site:${d}`))
+    .join(' OR ');
+}
 
 export async function POST(req: Request) {
-  const { query } = await req.json();
+  const { query, materialType } = await req.json();
   const key = process.env.BING_API_KEY;
   if (!key) {
     // Fallback static suggestions
     return NextResponse.json({
       results: [
-        { title: 'India Code — Search', url: 'https://www.indiacode.nic.in/', snippet: 'Official repository of Acts and subordinate legislation.' },
-        { title: 'e-Gazette of India', url: 'https://egazette.nic.in/', snippet: 'Official Gazette notifications.' },
-        { title: 'Supreme Court of India — Judgments', url: 'https://main.sci.gov.in/judgments', snippet: 'Official judgments.' }
+        {
+          title: 'India Code — Search',
+          url: 'https://www.indiacode.nic.in/',
+          snippet: 'Official repository of Acts and subordinate legislation.',
+          score: 1
+        },
+        {
+          title: 'e-Gazette of India',
+          url: 'https://egazette.nic.in/',
+          snippet: 'Official Gazette notifications.',
+          score: 1
+        },
+        {
+          title: 'Supreme Court of India — Judgments',
+          url: 'https://main.sci.gov.in/judgments',
+          snippet: 'Official judgments.',
+          score: 1
+        }
       ]
     });
   }
 
   // Use Bing Web Search v7
-  const domainFilter = 'site:indiacode.nic.in OR site:egazette.nic.in OR site:sci.gov.in OR (site:gov.in "High Court")';
-  const q = `${query} ${domainFilter}`;
+  const domainFilter = buildDomainFilter(materialType);
+  const q = `${query} (${domainFilter})`;
   const url = `https://api.bing.microsoft.com/v7.0/search?q=${encodeURIComponent(q)}&mkt=en-IN&count=10&responseFilter=Webpages`;
 
   const r = await fetch(url, { headers: { 'Ocp-Apim-Subscription-Key': key } });
@@ -33,10 +75,34 @@ export async function POST(req: Request) {
     return NextResponse.json({ results: [] });
   }
   const data = await r.json();
-  const results = (data.webPages?.value || []).map((x: any) => ({
-    title: x.name,
-    url: x.url,
-    snippet: x.snippet
-  }));
+  const keywords = query.toLowerCase().split(/\s+/).filter(Boolean);
+  const domainWeights: Record<string, number> = {
+    'indiankanoon.org': 5,
+    'main.sci.gov.in': 5,
+    'sci.gov.in': 5,
+    'egazette.nic.in': 4,
+    'indiacode.nic.in': 4,
+    'lawcommissionofindia.nic.in': 3,
+    'academic.oup.com': 2,
+    'journals.sagepub.com': 2
+  };
+
+  const results = (data.webPages?.value || [])
+    .map((x: any) => {
+      const domain = new URL(x.url).hostname;
+      let score = domainWeights[domain] || 0;
+      if (domain.includes('highcourt')) score = Math.max(score, 4);
+      const text = `${x.name} ${x.snippet}`.toLowerCase();
+      for (const k of keywords) {
+        if (text.includes(k)) score += 1;
+      }
+      return {
+        title: x.name,
+        url: x.url,
+        snippet: x.snippet,
+        score
+      };
+    })
+    .sort((a: any, b: any) => b.score - a.score);
   return NextResponse.json({ results });
 }


### PR DESCRIPTION
## Summary
- support `materialType` to switch between case law and research domain sets
- add simple relevance scoring and prioritized legal domains
- document websearch API parameter and response structure

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ae963ff514832fb06e3d0538db99e5