### PR TITLE
build domain filter from DOMAINS in websearch route

### DIFF
--- a/app/api/websearch/route.ts
+++ b/app/api/websearch/route.ts
@@ -5,7 +5,6 @@ const DOMAINS = [
   'egazette.nic.in',
   'main.sci.gov.in',
   'sci.gov.in',
-  'highcourt',
   'gov.in'
 ];
 
@@ -24,7 +23,9 @@ export async function POST(req: Request) {
   }
 
   // Use Bing Web Search v7
-  const domainFilter = 'site:indiacode.nic.in OR site:egazette.nic.in OR site:sci.gov.in OR (site:gov.in "High Court")';
+  const domainFilter = DOMAINS.map((d) =>
+    d === 'gov.in' ? `(site:${d} "High Court")` : `site:${d}`
+  ).join(' OR ');
   const q = `${query} ${domainFilter}`;
   const url = `https://api.bing.microsoft.com/v7.0/search?q=${encodeURIComponent(q)}&mkt=en-IN&count=10&responseFilter=Webpages`;
 


### PR DESCRIPTION
## Summary
- build Bing websearch domain filter by joining DOMAINS list
- programmatically include gov.in High Court filtering

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts to configure ESLint)

------
https://chatgpt.com/codex/tasks/task_e_68ae98cc1f6c832f82165f89b2e2942a