### PR TITLE
Handle failed requests gracefully in ChatWindow

### DIFF
--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -30,6 +30,7 @@ export default function ChatWindow({ mode }: { mode: 'citizen'|'lawyer' }) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ q, mode, docs }),
       });
+      if (!res.ok) throw new Error('Server error');
       const data = await res.json();
       const text = data?.answer ?? 'No answer.';
       setMessages(m => [...m, { role: 'assistant', content: text }]);
@@ -54,14 +55,15 @@ export default function ChatWindow({ mode }: { mode: 'citizen'|'lawyer' }) {
     setUploadBusy(true);
     try {
       const res = await fetch('/api/upload', { method: 'POST', body: fd });
+      if (!res.ok) throw new Error('Upload failed');
       const data = await res.json();
       if (data?.files?.length) {
         setDocs(prev => [...prev, ...data.files]);
       } else {
-        alert('Could not read those files.');
+        setMessages(m => [...m, { role: 'assistant', content: '⚠️ Could not read those files.' }]);
       }
     } catch {
-      alert('Upload failed.');
+      setMessages(m => [...m, { role: 'assistant', content: '⚠️ Upload failed.' }]);
     } finally {
       setUploadBusy(false);
       if (fileInputRef.current) fileInputRef.current.value = '';


### PR DESCRIPTION
## Summary
- Guard JSON parsing in chat request handlers by checking `res.ok` first
- Display in-app error messages instead of alerts when uploads or answers fail
- Always clear loading flags on error to keep the interface responsive

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompted for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ae98ce90a4832fa71b741f6ac8ece3