### PR TITLE
Replace brand color usage with neutral greys

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,7 +13,7 @@ body {
 }
 
 .card {
-  @apply bg-white border border-slate-200 rounded-2xl shadow-soft;
+  @apply bg-white border border-slate-200 rounded-2xl shadow-card;
 }
 
 .btn {
@@ -21,7 +21,7 @@ body {
 }
 
 .input {
-  @apply w-full rounded-xl border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500;
+  @apply w-full rounded-xl border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-slate-500;
 }
 
 .prose-custom {

--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -32,7 +32,7 @@ export default function LibraryPage() {
               <ul className="mt-3 space-y-1">
                 {m.sources.map((s,i)=>(
                   <li key={i} className="text-xs">
-                    <a className="text-brand hover:underline" href={s.url} target="_blank">{s.title}</a>{' '}
+                    <a className="text-zinc-700 hover:underline" href={s.url} target="_blank">{s.title}</a>{' '}
                     {s.tag && <span className="ml-1 px-1.5 py-0.5 text-[10px] bg-zinc-100 rounded">{s.tag}</span>}
                   </li>
                 ))}

--- a/components/Composer.tsx
+++ b/components/Composer.tsx
@@ -35,12 +35,12 @@ export default function Composer({
         onKeyDown={handleKeyDown}
         placeholder="Type your question… (Shift+Enter for a new line)"
         rows={1}
-        className="flex-1 resize-none outline-none bg-transparent px-3 py-2 rounded-xl border border-slate-300 focus:border-brand-500"
+        className="flex-1 resize-none outline-none bg-transparent px-3 py-2 rounded-xl border border-slate-300 focus:border-slate-500"
       />
       <button
         onClick={doSend}
         disabled={disabled || val.trim().length === 0}
-        className="px-4 py-2 rounded-xl bg-brand-600 text-white disabled:opacity-50 disabled:cursor-not-allowed hover:bg-brand-500 transition"
+        className="px-4 py-2 rounded-xl bg-slate-800 text-white disabled:opacity-50 disabled:cursor-not-allowed hover:bg-slate-700 transition"
         aria-label="Send"
       >
         Send

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,14 +8,6 @@ const config: Config = {
   ],
   theme: {
     extend: {
-      colors: {
-        brand: {
-          50: "#eef6ff",
-          100: "#d9ebff",
-          500: "#2563eb",
-          600: "#1d4ed8"
-        }
-      },
       borderRadius: {
         xl: "0.875rem",
         "2xl": "1rem"


### PR DESCRIPTION
## Summary
- replace custom brand colors with slate/black accents
- drop brand palette from tailwind config
- use grey links in library page and slate button in composer

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `CI=1 npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ae9ccff3a8832fad8a10dcbd24523f