### PR TITLE
Validate URLs and reject private IPs

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,7 +13,7 @@ body {
 }
 
 .card {
-  @apply bg-white border border-slate-200 rounded-2xl shadow-soft;
+  @apply bg-white border border-slate-200 rounded-2xl shadow-card;
 }
 
 .btn {

--- a/lib/url.test.ts
+++ b/lib/url.test.ts
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { validateUrl } from './url.ts';
+
+test('rejects private IPv4 addresses', () => {
+  assert.equal(validateUrl('http://10.0.0.1'), false);
+  assert.equal(validateUrl('http://127.0.0.1'), false);
+  assert.equal(validateUrl('http://169.254.0.1'), false);
+  assert.equal(validateUrl('http://172.16.0.1'), false);
+  assert.equal(validateUrl('http://192.168.1.1'), false);
+});
+
+test('rejects localhost and IPv6 loopback', () => {
+  assert.equal(validateUrl('http://localhost'), false);
+  assert.equal(validateUrl('http://[::1]'), false);
+});
+
+test('rejects invalid protocol', () => {
+  assert.equal(validateUrl('ftp://example.com'), false);
+});
+
+test('accepts public URLs', () => {
+  assert.equal(validateUrl('https://example.com'), true);
+  assert.equal(validateUrl('http://8.8.8.8'), true);
+});

--- a/lib/url.ts
+++ b/lib/url.ts
@@ -1,0 +1,43 @@
+import { isIP } from 'node:net';
+
+function ipToLong(ip: string): number {
+  return ip.split('.').reduce((acc, oct) => (acc << 8) + Number(oct), 0);
+}
+
+const privateRanges: Array<[number, number]> = [
+  [ipToLong('10.0.0.0'), ipToLong('10.255.255.255')],
+  [ipToLong('127.0.0.0'), ipToLong('127.255.255.255')],
+  [ipToLong('169.254.0.0'), ipToLong('169.254.255.255')],
+  [ipToLong('172.16.0.0'), ipToLong('172.31.255.255')],
+  [ipToLong('192.168.0.0'), ipToLong('192.168.255.255')],
+];
+
+function isPrivateIPv4(ip: string): boolean {
+  const long = ipToLong(ip);
+  return privateRanges.some(([start, end]) => long >= start && long <= end);
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  const h = ip.toLowerCase();
+  return h === '::1' || h.startsWith('fc') || h.startsWith('fd') || h.startsWith('fe80');
+}
+
+export function validateUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+    const hostname = parsed.hostname.toLowerCase();
+    if (hostname === 'localhost') return false;
+
+    const nakedHost = hostname.startsWith('[') && hostname.endsWith(']')
+      ? hostname.slice(1, -1)
+      : hostname;
+    const ipVersion = isIP(nakedHost);
+    if (ipVersion === 4 && isPrivateIPv4(nakedHost)) return false;
+    if (ipVersion === 6 && isPrivateIPv6(nakedHost)) return false;
+
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add URL validator that rejects private network addresses and disallows non-http protocols
- cover URL validator with tests for private IPv4/IPv6, localhost, and public URLs
- replace unsupported `shadow-soft` class with Tailwind `shadow-card` to fix build

## Testing
- `node --experimental-strip-types --test lib/url.test.ts`
- `npm run lint` *(fails: requires manual configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aea1515654832f985f3b7670dfc06f