### PR TITLE
feat: add multi-engine search aggregator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.env.local
+.env
+.next
+dist

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A simple, elegant, ChatGPT-style legal search interface with **New chat**, **Sea
 - Save any AI answer to your Library
 - Lawyer trial limiter: 10 prompts/month on the free plan
 - Basic API route `/api/answer` with OpenAI support if you set a key; otherwise mock answers with official source links
+- Unified search module that queries Bing, Google and optional legal databases, dedupes results and returns a single response
 - Legal pages: Disclaimer, Terms, Privacy, Sourcing
 
 ## Quick start
@@ -38,6 +39,8 @@ pnpm dev   # then open http://localhost:3000
 
 ## Optional retrieval keys
 - `BING_API_KEY` – for official-domain web search (India Code, e-Gazette, Supreme Court, etc.).
+- `GOOGLE_API_KEY` and `GOOGLE_CSE_ID` – enable Google Custom Search as an additional source.
+- `LEGAL_DB_SEARCH_URL` – HTTP endpoint for any in-house legal database search API.
 - `NEXT_PUBLIC_BASE_URL` – set this to your deployed base URL so the server can call its own `/api/scrape` in production.
 - `PREFER_HINDI=1` – environment flag to prefer Hindi for Citizen answers.
 
@@ -45,6 +48,9 @@ Example `.env.local`:
 ```
 OPENAI_API_KEY=sk-...
 BING_API_KEY=...
+GOOGLE_API_KEY=...
+GOOGLE_CSE_ID=...
+LEGAL_DB_SEARCH_URL=https://legal.example.com/search
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 # PREFER_HINDI=1
 ```

--- a/app/api/websearch/route.ts
+++ b/app/api/websearch/route.ts
@@ -1,42 +1,11 @@
 import { NextResponse } from 'next/server';
-
-const DOMAINS = [
-  'indiacode.nic.in',
-  'egazette.nic.in',
-  'main.sci.gov.in',
-  'sci.gov.in',
-  'highcourt',
-  'gov.in'
-];
+import { multiSearch } from '@/lib/multi-search';
 
 export async function POST(req: Request) {
   const { query } = await req.json();
-  const key = process.env.BING_API_KEY;
-  if (!key) {
-    // Fallback static suggestions
-    return NextResponse.json({
-      results: [
-        { title: 'India Code — Search', url: 'https://www.indiacode.nic.in/', snippet: 'Official repository of Acts and subordinate legislation.' },
-        { title: 'e-Gazette of India', url: 'https://egazette.nic.in/', snippet: 'Official Gazette notifications.' },
-        { title: 'Supreme Court of India — Judgments', url: 'https://main.sci.gov.in/judgments', snippet: 'Official judgments.' }
-      ]
-    });
+  const { results, message } = await multiSearch(query);
+  if (message) {
+    return NextResponse.json({ results: [], message });
   }
-
-  // Use Bing Web Search v7
-  const domainFilter = 'site:indiacode.nic.in OR site:egazette.nic.in OR site:sci.gov.in OR (site:gov.in "High Court")';
-  const q = `${query} ${domainFilter}`;
-  const url = `https://api.bing.microsoft.com/v7.0/search?q=${encodeURIComponent(q)}&mkt=en-IN&count=10&responseFilter=Webpages`;
-
-  const r = await fetch(url, { headers: { 'Ocp-Apim-Subscription-Key': key } });
-  if (!r.ok) {
-    return NextResponse.json({ results: [] });
-  }
-  const data = await r.json();
-  const results = (data.webPages?.value || []).map((x: any) => ({
-    title: x.name,
-    url: x.url,
-    snippet: x.snippet
-  }));
   return NextResponse.json({ results });
 }

--- a/lib/multi-search.ts
+++ b/lib/multi-search.ts
@@ -1,0 +1,86 @@
+export interface SearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+  engine: string;
+}
+
+async function bingSearch(query: string): Promise<SearchResult[]> {
+  const key = process.env.BING_API_KEY;
+  if (!key) return [];
+  const domainFilter =
+    'site:indiacode.nic.in OR site:egazette.nic.in OR site:sci.gov.in OR (site:gov.in "High Court")';
+  const q = `${query} ${domainFilter}`;
+  const url = `https://api.bing.microsoft.com/v7.0/search?q=${encodeURIComponent(
+    q
+  )}&mkt=en-IN&count=10&responseFilter=Webpages`;
+  const r = await fetch(url, {
+    headers: { 'Ocp-Apim-Subscription-Key': key },
+  }).catch(() => null);
+  if (!r || !r.ok) return [];
+  const data = await r.json().catch(() => ({}));
+  return (data.webPages?.value || []).map((x: any) => ({
+    title: x.name,
+    url: x.url,
+    snippet: x.snippet,
+    engine: 'bing',
+  }));
+}
+
+async function googleSearch(query: string): Promise<SearchResult[]> {
+  const key = process.env.GOOGLE_API_KEY;
+  const cx = process.env.GOOGLE_CSE_ID;
+  if (!key || !cx) return [];
+  const url = `https://www.googleapis.com/customsearch/v1?key=${key}&cx=${cx}&q=${encodeURIComponent(
+    query
+  )}`;
+  const r = await fetch(url).catch(() => null);
+  if (!r || !r.ok) return [];
+  const data = await r.json().catch(() => ({}));
+  return (data.items || []).map((x: any) => ({
+    title: x.title,
+    url: x.link,
+    snippet: x.snippet,
+    engine: 'google',
+  }));
+}
+
+async function legalDbSearch(query: string): Promise<SearchResult[]> {
+  const endpoint = process.env.LEGAL_DB_SEARCH_URL;
+  if (!endpoint) return [];
+  const url = `${endpoint}?q=${encodeURIComponent(query)}`;
+  const r = await fetch(url).catch(() => null);
+  if (!r || !r.ok) return [];
+  const data = await r.json().catch(() => ({}));
+  if (!Array.isArray(data.results)) return [];
+  return data.results.map((x: any) => ({
+    title: x.title,
+    url: x.url,
+    snippet: x.snippet || '',
+    engine: 'legal',
+  }));
+}
+
+export async function multiSearch(query: string) {
+  const engines = [bingSearch, googleSearch, legalDbSearch];
+  const settled = await Promise.allSettled(engines.map((fn) => fn(query)));
+  let results: SearchResult[] = [];
+  for (const s of settled) {
+    if (s.status === 'fulfilled') results = results.concat(s.value);
+  }
+  const seen = new Set<string>();
+  const deduped: SearchResult[] = [];
+  for (const r of results) {
+    if (seen.has(r.url)) continue;
+    seen.add(r.url);
+    deduped.push(r);
+  }
+  if (!deduped.length) {
+    return {
+      results: [],
+      message:
+        "Sorry, I couldn't find relevant information. Please refine your question or try again later.",
+    };
+  }
+  return { results: deduped };
+}


### PR DESCRIPTION
## Summary
- add multi-engine search module hitting Bing, Google, and optional legal DB with deduplication and graceful fallback
- expose multi-engine search via `/api/websearch`
- document new env vars for Google and legal DB search; ignore build artifacts

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*


------
https://chatgpt.com/codex/tasks/task_e_68aea6f143c4832fb43dbe604f8e3b96