### PR TITLE
Integrate web search results into answer prompt and display citations

### DIFF
--- a/components/MessageBubble.tsx
+++ b/components/MessageBubble.tsx
@@ -5,9 +5,11 @@ import clsx from 'clsx';
 export default function MessageBubble({
   role,
   content,
+  sources,
 }: {
   role: 'user' | 'assistant';
   content: string;
+  sources?: { title: string; url: string }[];
 }) {
   return (
     <div className={clsx(
@@ -19,6 +21,22 @@ export default function MessageBubble({
       </div>
       <div className="text-sm leading-7">
         <Markdown>{content}</Markdown>
+        {sources?.length ? (
+          <ol className="mt-3 space-y-1 text-xs">
+            {sources.map((s, i) => (
+              <li key={i}>
+                <a
+                  href={s.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline"
+                >
+                  [{i + 1}] {s.title}
+                </a>
+              </li>
+            ))}
+          </ol>
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- query `/api/websearch` before requesting an answer and forward web results to the server
- extend answer API to accept web results, summarize them, and prepend the summary to the model prompt
- render optional citation list in message bubbles using sources returned from the API

## Testing
- `npm test` *(fails: Missing script: "test")*
- `CI=1 npm run lint` *(fails: Invalid Options from next lint)*

------
https://chatgpt.com/codex/tasks/task_e_68aebf1ccd34832f9ad3aa0f6f152736