### PR TITLE
feat: integrate web search results and citations

### DIFF
--- a/components/MessageBubble.tsx
+++ b/components/MessageBubble.tsx
@@ -5,9 +5,11 @@ import clsx from 'clsx';
 export default function MessageBubble({
   role,
   content,
+  sources,
 }: {
   role: 'user' | 'assistant';
   content: string;
+  sources?: Array<{ title: string; url: string }>;
 }) {
   return (
     <div className={clsx(
@@ -19,6 +21,15 @@ export default function MessageBubble({
       </div>
       <div className="text-sm leading-7">
         <Markdown>{content}</Markdown>
+        {sources?.length ? (
+          <ol className="mt-2 space-y-1 text-xs">
+            {sources.map((s, i) => (
+              <li key={i}>
+                [{i + 1}] <a href={s.url} target="_blank" className="underline">{s.title || s.url}</a>
+              </li>
+            ))}
+          </ol>
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Fetch web search results for each query and send them to the answer API
- Allow answer route to prepend summarized web results and return them as sources
- Display returned sources with citation links in chat messages

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68aebdd68a1c832fa610f59581f118d8