### PR TITLE
feat: add memory eviction

### DIFF
--- a/lib/memory.test.ts
+++ b/lib/memory.test.ts
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { configureMemory, updateContext, getContext, memorySize, purgeStale } from './memory.ts';
+
+test('removes entries older than maxAgeMs', { concurrency: false }, async () => {
+  configureMemory({ maxAgeMs: 10, maxEntries: 100 });
+  updateContext('u1', { lastQ: 'hi' });
+  await new Promise(r => setTimeout(r, 15));
+  purgeStale();
+  assert.strictEqual(memorySize(), 0);
+});
+
+test('evicts oldest when exceeding maxEntries', { concurrency: false }, () => {
+  configureMemory({ maxEntries: 2, maxAgeMs: 1000 });
+  updateContext('a', { lastQ: '1' });
+  updateContext('b', { lastQ: '2' });
+  updateContext('c', { lastQ: '3' });
+  purgeStale();
+  assert.strictEqual(memorySize(), 2);
+  assert.deepStrictEqual(getContext('a'), {});
+  assert.strictEqual(getContext('b').lastQ, '2');
+  assert.strictEqual(getContext('c').lastQ, '3');
+});


### PR DESCRIPTION
## Summary
- add configurable TTL/size limits to in-memory context store
- purge stale entries and expose utilities for configuration
- add unit tests for TTL expiry and LRU eviction

## Testing
- `TS_NODE_COMPILER_OPTIONS='{"allowImportingTsExtensions": true }' node --require ts-node/register --test lib/memory.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aeb6c7a3bc832fba69dc3b53e5ba90