### PR TITLE
Validate and whitelist scrape URLs

### DIFF
--- a/app/api/scrape/route.ts
+++ b/app/api/scrape/route.ts
@@ -7,8 +7,23 @@ export async function POST(req: Request) {
     if (!url || typeof url !== 'string') {
       return NextResponse.json({ error: 'Missing url' }, { status: 400 });
     }
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      return NextResponse.json({ error: 'Invalid url' }, { status: 400 });
+    }
 
-    const res = await fetch(url, { redirect: 'follow' });
+    if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+      return NextResponse.json({ error: 'Invalid protocol' }, { status: 400 });
+    }
+
+    const allowedDomains = ['example.com'];
+    if (!allowedDomains.includes(parsedUrl.hostname)) {
+      return NextResponse.json({ error: 'Domain not allowed' }, { status: 400 });
+    }
+
+    const res = await fetch(parsedUrl.toString(), { redirect: 'follow' });
     const html = await res.text();
 
     // Try Readability first (clean article)


### PR DESCRIPTION
## Summary
- validate scrape URL with `new URL`
- enforce http(s) scheme and an allowed domain list
- return 400 for invalid or disallowed URLs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68aec7f9d3fc832fb4fb3e2c234e5ea7