### PR TITLE
Validate and sanitize websearch queries

### DIFF
--- a/app/api/websearch/route.ts
+++ b/app/api/websearch/route.ts
@@ -1,9 +1,20 @@
 import { NextResponse } from 'next/server';
 import { multiSearch } from '@/lib/multi-search';
 
+const MAX_QUERY_LENGTH = 500;
+
 export async function POST(req: Request) {
-  const { query } = await req.json();
-  const { results, message } = await multiSearch(query);
+  const body = await req.json().catch(() => ({}));
+  const query = typeof body.query === 'string' ? body.query.trim() : '';
+  if (!query) {
+    return NextResponse.json(
+      { results: [], message: 'Please provide a search query.' },
+      { status: 400 },
+    );
+  }
+
+  const safeQuery = query.slice(0, MAX_QUERY_LENGTH);
+  const { results, message } = await multiSearch(safeQuery);
   if (message) {
     return NextResponse.json({ results: [], message });
   }


### PR DESCRIPTION
## Summary
- Parse request body defensively in the websearch API route.
- Return 400 when query is missing or empty.
- Trim and cap query length before invoking multiSearch.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68aec7f64824832f85e96632d55bb8ea