### PR TITLE
fix: correct missing card shadow utility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,7 +13,8 @@ body {
 }
 
 .card {
-  @apply bg-white border border-slate-200 rounded-2xl shadow-soft;
+  /* Use custom card shadow defined in Tailwind config */
+  @apply bg-white border border-slate-200 rounded-2xl shadow-card;
 }
 
 .btn {


### PR DESCRIPTION
## Summary
- replace undefined `shadow-soft` class with Tailwind's configured `shadow-card`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aecaafa8f8832fb5ed6040dda1d8ce