### PR TITLE
feat: add SEO metadata to pages

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,7 +13,7 @@ body {
 }
 
 .card {
-  @apply bg-white border border-slate-200 rounded-2xl shadow-soft;
+  @apply bg-white border border-slate-200 rounded-2xl shadow-card;
 }
 
 .btn {

--- a/app/legal/disclaimer/page.tsx
+++ b/app/legal/disclaimer/page.tsx
@@ -1,3 +1,27 @@
+import type { Metadata } from 'next';
+
+const url = 'https://lexlens.ai/legal/disclaimer';
+
+export const metadata: Metadata = {
+  title: 'Disclaimer – LexLens',
+  description: 'Important disclaimers about using LexLens. Informational only; not legal advice.',
+  alternates: {
+    canonical: url,
+  },
+  openGraph: {
+    title: 'Disclaimer – LexLens',
+    description: 'Important disclaimers about using LexLens. Informational only; not legal advice.',
+    url,
+    siteName: 'LexLens',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Disclaimer – LexLens',
+    description: 'Important disclaimers about using LexLens. Informational only; not legal advice.',
+  },
+};
+
 export default function DisclaimerPage() {
   return (
     <div className="prose max-w-3xl">
@@ -6,5 +30,5 @@ export default function DisclaimerPage() {
       <p><strong>No confidentiality.</strong> Do not share sensitive personal data or case details. Using this service does not create attorney–client privilege.</p>
       <p><strong>Jurisdiction variance.</strong> Laws differ by state and change over time. Content may not reflect the latest updates. Always verify via linked sources.</p>
     </div>
-  )
+  );
 }

--- a/app/legal/privacy/page.tsx
+++ b/app/legal/privacy/page.tsx
@@ -1,8 +1,32 @@
+import type { Metadata } from 'next';
+
+const url = 'https://lexlens.ai/legal/privacy';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy – LexLens',
+  description: 'How LexLens collects, uses, and protects your data.',
+  alternates: {
+    canonical: url,
+  },
+  openGraph: {
+    title: 'Privacy Policy – LexLens',
+    description: 'How LexLens collects, uses, and protects your data.',
+    url,
+    siteName: 'LexLens',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Privacy Policy – LexLens',
+    description: 'How LexLens collects, uses, and protects your data.',
+  },
+};
+
 export default function PrivacyPage() {
   return (
     <div className="prose max-w-3xl">
       <h1>Privacy Policy</h1>
       <p>We collect minimal data to operate the service: account details, queries, and usage telemetry. We keep query logs for no more than 90 days and support data-rights requests. For the DPDP-compliant full policy, replace this text with your customized policy from the canvas.</p>
     </div>
-  )
+  );
 }

--- a/app/legal/sourcing/page.tsx
+++ b/app/legal/sourcing/page.tsx
@@ -1,8 +1,32 @@
+import type { Metadata } from 'next';
+
+const url = 'https://lexlens.ai/legal/sourcing';
+
+export const metadata: Metadata = {
+  title: 'Attribution & Sourcing – LexLens',
+  description: 'Learn about the official sources behind LexLens answers and citations.',
+  alternates: {
+    canonical: url,
+  },
+  openGraph: {
+    title: 'Attribution & Sourcing – LexLens',
+    description: 'Learn about the official sources behind LexLens answers and citations.',
+    url,
+    siteName: 'LexLens',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Attribution & Sourcing – LexLens',
+    description: 'Learn about the official sources behind LexLens answers and citations.',
+  },
+};
+
 export default function SourcingPage() {
   return (
     <div className="prose max-w-3xl">
       <h1>Attribution &amp; Sourcing</h1>
       <p>We prioritize official sources such as India Code, the Gazette of India, and Supreme/High Court websites. We do not ingest proprietary headnotes or commercial digests. Every answer includes citations and direct links to primary materials.</p>
     </div>
-  )
+  );
 }

--- a/app/legal/terms/page.tsx
+++ b/app/legal/terms/page.tsx
@@ -1,3 +1,27 @@
+import type { Metadata } from 'next';
+
+const url = 'https://lexlens.ai/legal/terms';
+
+export const metadata: Metadata = {
+  title: 'Terms of Service – LexLens',
+  description: 'Rules and conditions for using the LexLens service.',
+  alternates: {
+    canonical: url,
+  },
+  openGraph: {
+    title: 'Terms of Service – LexLens',
+    description: 'Rules and conditions for using the LexLens service.',
+    url,
+    siteName: 'LexLens',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Terms of Service – LexLens',
+    description: 'Rules and conditions for using the LexLens service.',
+  },
+};
+
 export default function TermsPage() {
   return (
     <div className="prose max-w-3xl">
@@ -5,5 +29,5 @@ export default function TermsPage() {
       <p>These Terms govern your use of the site and services provided by LexLens. By using our Services you agree to these Terms. This service provides general legal information and links to official sources. It does not provide legal advice or create an attorney–client relationship.</p>
       <p>Use is subject to fair use and rate limits. Do not upload case files or personal data. For full, customizable Terms, see the canvas doc in your project or contact legal@yourdomain.</p>
     </div>
-  )
+  );
 }

--- a/app/library/library-client.tsx
+++ b/app/library/library-client.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { loadChats } from '@/lib/storage';
+import type { Message } from '@/lib/types';
+import { useEffect, useState } from 'react';
+
+export default function LibraryClient() {
+  const [saved, setSaved] = useState<Message[]>([]);
+  useEffect(() => {
+    function refresh() {
+      const all = loadChats();
+      const msgs = all.flatMap(c => c.messages.filter(m => m.saved));
+      setSaved(msgs.sort((a,b)=>b.createdAt-a.createdAt));
+    }
+    refresh();
+    window.addEventListener('app:chats', refresh);
+    return () => window.removeEventListener('app:chats', refresh);
+  }, []);
+
+  return (
+    <div className="w-full">
+      <div className="mb-4">
+        <h1 className="text-xl font-semibold">Library</h1>
+        <p className="text-sm text-zinc-600">Saved answers with their sources.</p>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+        {saved.length === 0 && <div className="text-sm text-zinc-500">Nothing saved yet.</div>}
+        {saved.map(m => (
+          <div key={m.id} className="rounded-xl border border-zinc-200 bg-white p-4">
+            <div className="text-sm whitespace-pre-wrap">{m.content}</div>
+            {m.sources && m.sources.length > 0 && (
+              <ul className="mt-3 space-y-1">
+                {m.sources.map((s,i)=>(
+                  <li key={i} className="text-xs">
+                    <a className="text-brand hover:underline" href={s.url} target="_blank">{s.title}</a>{' '}
+                    {s.tag && <span className="ml-1 px-1.5 py-0.5 text-[10px] bg-zinc-100 rounded">{s.tag}</span>}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -1,46 +1,28 @@
-'use client';
+import LibraryClient from './library-client';
+import type { Metadata } from 'next';
 
-import { loadChats } from '@/lib/storage';
-import type { Message } from '@/lib/types';
-import { useEffect, useState } from 'react';
+const url = 'https://lexlens.ai/library';
 
-export default function LibraryPage() {
-  const [saved, setSaved] = useState<Message[]>([]);
-  useEffect(() => {
-    function refresh() {
-      const all = loadChats();
-      const msgs = all.flatMap(c => c.messages.filter(m => m.saved));
-      setSaved(msgs.sort((a,b)=>b.createdAt-a.createdAt));
-    }
-    refresh();
-    window.addEventListener('app:chats', refresh);
-    return () => window.removeEventListener('app:chats', refresh);
-  }, []);
+export const metadata: Metadata = {
+  title: 'Library – LexLens',
+  description: 'Browse your saved legal answers and source citations.',
+  alternates: {
+    canonical: url,
+  },
+  openGraph: {
+    title: 'Library – LexLens',
+    description: 'Browse your saved legal answers and source citations.',
+    url,
+    siteName: 'LexLens',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Library – LexLens',
+    description: 'Browse your saved legal answers and source citations.',
+  },
+};
 
-  return (
-    <div className="w-full">
-      <div className="mb-4">
-        <h1 className="text-xl font-semibold">Library</h1>
-        <p className="text-sm text-zinc-600">Saved answers with their sources.</p>
-      </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-        {saved.length === 0 && <div className="text-sm text-zinc-500">Nothing saved yet.</div>}
-        {saved.map(m => (
-          <div key={m.id} className="rounded-xl border border-zinc-200 bg-white p-4">
-            <div className="text-sm whitespace-pre-wrap">{m.content}</div>
-            {m.sources && m.sources.length > 0 && (
-              <ul className="mt-3 space-y-1">
-                {m.sources.map((s,i)=>(
-                  <li key={i} className="text-xs">
-                    <a className="text-brand hover:underline" href={s.url} target="_blank">{s.title}</a>{' '}
-                    {s.tag && <span className="ml-1 px-1.5 py-0.5 text-[10px] bg-zinc-100 rounded">{s.tag}</span>}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+export default function Page() {
+  return <LibraryClient />;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,27 @@
 import HomeClient from './home-client';
+import type { Metadata } from 'next';
+
+const baseUrl = 'https://lexlens.ai';
+
+export const metadata: Metadata = {
+  title: 'LexLens — Legal Search AI',
+  description: 'Chat-style legal answers with citations from official sources.',
+  alternates: {
+    canonical: baseUrl,
+  },
+  openGraph: {
+    title: 'LexLens — Legal Search AI',
+    description: 'Chat-style legal answers with citations from official sources.',
+    url: baseUrl,
+    siteName: 'LexLens',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'LexLens — Legal Search AI',
+    description: 'Chat-style legal answers with citations from official sources.',
+  },
+};
 
 export default function Page() {
   return <HomeClient />;

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,36 +1,28 @@
-'use client';
+import SearchClient from './search-client';
+import type { Metadata } from 'next';
 
-import { useMemo, useState } from 'react';
-import { loadChats } from '@/lib/storage';
+const url = 'https://lexlens.ai/search';
 
-export default function SearchChatsPage() {
-  const [q, setQ] = useState('');
-  const chats = loadChats();
+export const metadata: Metadata = {
+  title: 'Search Chats – LexLens',
+  description: 'Find answers across your previous LexLens conversations.',
+  alternates: {
+    canonical: url,
+  },
+  openGraph: {
+    title: 'Search Chats – LexLens',
+    description: 'Find answers across your previous LexLens conversations.',
+    url,
+    siteName: 'LexLens',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Search Chats – LexLens',
+    description: 'Find answers across your previous LexLens conversations.',
+  },
+};
 
-  const results = useMemo(()=>{
-    const t = q.trim().toLowerCase();
-    if (!t) return [];
-    return chats.flatMap(c => c.messages.map(m => ({ chatId: c.id, title: c.title, content: m.content, createdAt: m.createdAt })))
-      .filter(x => x.content.toLowerCase().includes(t) || (x.title?.toLowerCase().includes(t)))
-      .sort((a,b)=>b.createdAt-a.createdAt)
-      .slice(0, 200);
-  }, [q, chats]);
-
-  return (
-    <div className="w-full">
-      <h1 className="text-xl font-semibold mb-4">Search chats</h1>
-      <div className="mb-4">
-        <input value={q} onChange={e=>setQ(e.target.value)} placeholder="Search across all your chats…" className="w-full md:w-2/3 px-3 py-2 rounded-lg border border-zinc-300"/>
-      </div>
-      <div className="space-y-3">
-        {results.map((r, i)=> (
-          <a key={i} href={`/?id=${r.chatId}`} className="block rounded-lg border border-zinc-200 bg-white p-3 hover:bg-zinc-50">
-            <div className="text-sm font-medium">{r.title || 'Untitled'}</div>
-            <div className="text-xs text-zinc-600 line-clamp-2">{r.content}</div>
-          </a>
-        ))}
-        {q && results.length === 0 && <div className="text-sm text-zinc-500">No matches found.</div>}
-      </div>
-    </div>
-  );
+export default function Page() {
+  return <SearchClient />;
 }

--- a/app/search/search-client.tsx
+++ b/app/search/search-client.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { loadChats } from '@/lib/storage';
+
+export default function SearchClient() {
+  const [q, setQ] = useState('');
+  const chats = loadChats();
+
+  const results = useMemo(()=>{
+    const t = q.trim().toLowerCase();
+    if (!t) return [];
+    return chats.flatMap(c => c.messages.map(m => ({ chatId: c.id, title: c.title, content: m.content, createdAt: m.createdAt })))
+      .filter(x => x.content.toLowerCase().includes(t) || (x.title?.toLowerCase().includes(t)))
+      .sort((a,b)=>b.createdAt-a.createdAt)
+      .slice(0, 200);
+  }, [q, chats]);
+
+  return (
+    <div className="w-full">
+      <h1 className="text-xl font-semibold mb-4">Search chats</h1>
+      <div className="mb-4">
+        <input value={q} onChange={e=>setQ(e.target.value)} placeholder="Search across all your chats…" className="w-full md:w-2/3 px-3 py-2 rounded-lg border border-zinc-300"/>
+      </div>
+      <div className="space-y-3">
+        {results.map((r, i)=> (
+          <a key={i} href={`/?id=${r.chatId}`} className="block rounded-lg border border-zinc-200 bg-white p-3 hover:bg-zinc-50">
+            <div className="text-sm font-medium">{r.title || 'Untitled'}</div>
+            <div className="text-xs text-zinc-600 line-clamp-2">{r.content}</div>
+          </a>
+        ))}
+        {q && results.length === 0 && <div className="text-sm text-zinc-500">No matches found.</div>}
+      </div>
+    </div>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,48 +1,28 @@
-'use client';
+import SettingsClient from './settings-client';
+import type { Metadata } from 'next';
 
-import { useEffect, useState } from 'react';
-import { loadState, saveState } from '@/lib/storage';
+const url = 'https://lexlens.ai/settings';
 
-export default function SettingsPage() {
-  const [plan, setPlan] = useState('free');
-  const [hindi, setHindi] = useState(false);
+export const metadata: Metadata = {
+  title: 'Settings – LexLens',
+  description: 'Manage your LexLens plan and language preferences.',
+  alternates: {
+    canonical: url,
+  },
+  openGraph: {
+    title: 'Settings – LexLens',
+    description: 'Manage your LexLens plan and language preferences.',
+    url,
+    siteName: 'LexLens',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Settings – LexLens',
+    description: 'Manage your LexLens plan and language preferences.',
+  },
+};
 
-  useEffect(() => {
-    const s = loadState();
-    setPlan(s.plan);
-    setHindi(localStorage.getItem('lexlens:hindi') === '1');
-  }, []);
-
-  function save() {
-    const s = loadState();
-    s.plan = plan as any;
-    saveState(s);
-    localStorage.setItem('lexlens:hindi', hindi ? '1' : '0');
-    alert('Saved!');
-  }
-
-  return (
-    <div className="w-full max-w-2xl">
-      <h1 className="text-xl font-semibold mb-4">Settings</h1>
-      <div className="space-y-6">
-        <div>
-          <div className="text-sm font-medium mb-2">Plan</div>
-          <select value={plan} onChange={e=>setPlan(e.target.value)} className="px-3 py-2 border rounded-lg">
-            <option value="free">Free</option>
-            <option value="citizen_plus">Citizen+</option>
-            <option value="lawyer_pro">Lawyer Pro</option>
-            <option value="firm">Firm</option>
-          </select>
-          <p className="text-xs text-zinc-500 mt-1">This is a local setting for demo. Billing integration will set this automatically.</p>
-        </div>
-        <div>
-          <label className="flex items-center gap-2 text-sm">
-            <input type="checkbox" checked={hindi} onChange={e=>setHindi(e.target.checked)} />
-            Prefer Hindi answers for Citizen mode
-          </label>
-        </div>
-        <button onClick={save} className="inline-flex items-center rounded-lg bg-zinc-900 text-white px-3 py-2 text-sm">Save</button>
-      </div>
-    </div>
-  )
+export default function Page() {
+  return <SettingsClient />;
 }

--- a/app/settings/settings-client.tsx
+++ b/app/settings/settings-client.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { loadState, saveState } from '@/lib/storage';
+
+export default function SettingsClient() {
+  const [plan, setPlan] = useState('free');
+  const [hindi, setHindi] = useState(false);
+
+  useEffect(() => {
+    const s = loadState();
+    setPlan(s.plan);
+    setHindi(localStorage.getItem('lexlens:hindi') === '1');
+  }, []);
+
+  function save() {
+    const s = loadState();
+    s.plan = plan as any;
+    saveState(s);
+    localStorage.setItem('lexlens:hindi', hindi ? '1' : '0');
+    alert('Saved!');
+  }
+
+  return (
+    <div className="w-full max-w-2xl">
+      <h1 className="text-xl font-semibold mb-4">Settings</h1>
+      <div className="space-y-6">
+        <div>
+          <div className="text-sm font-medium mb-2">Plan</div>
+          <select value={plan} onChange={e=>setPlan(e.target.value)} className="px-3 py-2 border rounded-lg">
+            <option value="free">Free</option>
+            <option value="citizen_plus">Citizen+</option>
+            <option value="lawyer_pro">Lawyer Pro</option>
+            <option value="firm">Firm</option>
+          </select>
+          <p className="text-xs text-zinc-500 mt-1">This is a local setting for demo. Billing integration will set this automatically.</p>
+        </div>
+        <div>
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={hindi} onChange={e=>setHindi(e.target.checked)} />
+            Prefer Hindi answers for Citizen mode
+          </label>
+        </div>
+        <button onClick={save} className="inline-flex items-center rounded-lg bg-zinc-900 text-white px-3 py-2 text-sm">Save</button>
+      </div>
+    </div>
+  );
+}

--- a/app/upgrade/page.tsx
+++ b/app/upgrade/page.tsx
@@ -1,4 +1,27 @@
 import Link from 'next/link';
+import type { Metadata } from 'next';
+
+const url = 'https://lexlens.ai/upgrade';
+
+export const metadata: Metadata = {
+  title: 'Upgrade – LexLens',
+  description: 'Compare LexLens plans and unlock Lawyer mode.',
+  alternates: {
+    canonical: url,
+  },
+  openGraph: {
+    title: 'Upgrade – LexLens',
+    description: 'Compare LexLens plans and unlock Lawyer mode.',
+    url,
+    siteName: 'LexLens',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Upgrade – LexLens',
+    description: 'Compare LexLens plans and unlock Lawyer mode.',
+  },
+};
 
 export default function UpgradePage() {
   return (
@@ -37,5 +60,5 @@ export default function UpgradePage() {
       </div>
       <p className="text-xs text-zinc-500 mt-6">This is a placeholder page. Billing will be wired with Stripe (test mode) when you’re ready.</p>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- add descriptive metadata, canonical URLs, and Open Graph/Twitter tags for every page
- split client-heavy pages into server wrappers with client components to enable metadata

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompted for ESLint configuration)*
- `npm run build` *(fails: "The `shadow-soft` class does not exist" in globals.css)*

------
https://chatgpt.com/codex/tasks/task_e_68aecdcd6fc4832f98b47c41cb7e5e4a