### PR TITLE
feat: add query rewriting for web search

### DIFF
--- a/app/api/websearch/route.ts
+++ b/app/api/websearch/route.ts
@@ -1,12 +1,19 @@
 import { NextResponse } from 'next/server';
-import { multiSearch } from '@/lib/multi-search';
+import { multiSearch, SearchResult } from '@/lib/multi-search';
 import { rewriteQuery } from '@/lib/rewrite-query';
+
+type WebSearchResponse = {
+  results: SearchResult[];
+  query: string;
+  rewrittenQuery: string;
+  message?: string;
+};
 
 export async function POST(req: Request) {
   const { query } = await req.json();
   const rewritten = await rewriteQuery(query);
   const { results, message } = await multiSearch(rewritten);
-  const payload: any = { results, query, rewrittenQuery: rewritten };
+  const payload: WebSearchResponse = { results, query, rewrittenQuery: rewritten };
   if (message) payload.message = message;
   return NextResponse.json(payload);
 }

--- a/app/api/websearch/route.ts
+++ b/app/api/websearch/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from 'next/server';
 import { multiSearch } from '@/lib/multi-search';
+import { rewriteQuery } from '@/lib/rewrite-query';
 
 export async function POST(req: Request) {
   const { query } = await req.json();
-  const { results, message } = await multiSearch(query);
-  if (message) {
-    return NextResponse.json({ results: [], message });
-  }
-  return NextResponse.json({ results });
+  const rewritten = await rewriteQuery(query);
+  const { results, message } = await multiSearch(rewritten);
+  const payload: any = { results, query, rewrittenQuery: rewritten };
+  if (message) payload.message = message;
+  return NextResponse.json(payload);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -13,7 +13,7 @@ body {
 }
 
 .card {
-  @apply bg-white border border-slate-200 rounded-2xl shadow-soft;
+  @apply bg-white border border-slate-200 rounded-2xl shadow-md;
 }
 
 .btn {

--- a/app/websearch/page.tsx
+++ b/app/websearch/page.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState } from 'react';
+import type { SearchResult } from '@/lib/multi-search';
+
+export default function WebSearchPage() {
+  const [q, setQ] = useState('');
+  const [orig, setOrig] = useState('');
+  const [rewritten, setRewritten] = useState('');
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [msg, setMsg] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function search() {
+    const query = q.trim();
+    if (!query || loading) return;
+    setLoading(true);
+    setMsg('');
+    try {
+      const res = await fetch('/api/websearch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query }),
+      });
+      const data = await res.json();
+      setResults(data.results || []);
+      setMsg(data.message || '');
+      setOrig(data.query || query);
+      setRewritten(data.rewrittenQuery || query);
+    } catch {
+      setMsg('Error contacting server.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Web search</h1>
+      <div className="flex gap-2">
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Type a question…"
+          className="flex-1 px-3 py-2 rounded border"
+        />
+        <button className="btn" onClick={search} disabled={loading || !q.trim()}>
+          {loading ? 'Searching…' : 'Search'}
+        </button>
+      </div>
+      {orig && (
+        <div className="text-sm text-zinc-600 space-y-1">
+          <div>Original: {orig}</div>
+          <div>Rewritten: {rewritten}</div>
+        </div>
+      )}
+      {msg && <div className="text-sm text-zinc-600">{msg}</div>}
+      <ul className="space-y-3">
+        {results.map((r, i) => (
+          <li key={i} className="border rounded p-3 hover:bg-zinc-50">
+            <a href={r.url} target="_blank" className="font-medium text-blue-600 hover:underline">
+              {r.title}
+            </a>
+            <div className="text-xs text-zinc-600 line-clamp-2">{r.snippet}</div>
+            <div className="text-[10px] text-zinc-400">{r.engine}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -18,6 +18,7 @@ export default function TopBar({ title = 'LexLens' }: Props) {
           </Link>
           <nav className="hidden sm:flex items-center gap-4 text-sm text-zinc-600">
             <Link href="/search" className="hover:text-black">Search</Link>
+            <Link href="/websearch" className="hover:text-black">Web</Link>
             <Link href="/library" className="hover:text-black">Library</Link>
             <Link href="/settings" className="hover:text-black">Settings</Link>
           </nav>

--- a/lib/rewrite-query.ts
+++ b/lib/rewrite-query.ts
@@ -1,0 +1,55 @@
+const PROVIDER = (process.env.AI_PROVIDER || 'gemini').toLowerCase();
+const GEMINI_MODEL = process.env.GEMINI_MODEL || 'gemini-1.5-flash';
+const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4o-mini';
+
+export async function rewriteQuery(q: string): Promise<string> {
+  const prompt = `Rewrite the following search query into a short, explicit search string focusing on key nouns and verbs. Respond with only the rewritten query.\n\nQuery: ${q}`;
+  try {
+    if (PROVIDER === 'openai') {
+      const key = process.env.OPENAI_API_KEY;
+      if (!key) return q;
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: OPENAI_MODEL,
+          temperature: 0,
+          max_tokens: 20,
+          messages: [
+            { role: 'system', content: 'You rewrite search queries into concise search engine strings.' },
+            { role: 'user', content: q }
+          ],
+        }),
+      }).catch(() => null);
+      const data = await res?.json().catch(() => ({}));
+      const text = data?.choices?.[0]?.message?.content?.trim();
+      return text || q;
+    } else {
+      const key = process.env.GEMINI_API_KEY;
+      if (!key) return q;
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(GEMINI_MODEL)}:generateContent?key=${key}`;
+      const body = {
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: prompt }],
+          },
+        ],
+        generationConfig: { temperature: 0, maxOutputTokens: 20 },
+      };
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }).catch(() => null);
+      const data = await res?.json().catch(() => ({}));
+      const parts = data?.candidates?.[0]?.content?.parts || [];
+      const text = parts.map((p: any) => p?.text ?? '').join('').trim();
+      return text || q;
+    }
+  } catch {
+    return q;
+  }
+}
+
+export default rewriteQuery;

--- a/lib/rewrite-query.ts
+++ b/lib/rewrite-query.ts
@@ -15,10 +15,7 @@ export async function rewriteQuery(q: string): Promise<string> {
           model: OPENAI_MODEL,
           temperature: 0,
           max_tokens: 20,
-          messages: [
-            { role: 'system', content: 'You rewrite search queries into concise search engine strings.' },
-            { role: 'user', content: q }
-          ],
+          messages: [{ role: 'user', content: prompt }],
         }),
       }).catch(() => null);
       const data = await res?.json().catch(() => ({}));
@@ -43,8 +40,9 @@ export async function rewriteQuery(q: string): Promise<string> {
         body: JSON.stringify(body),
       }).catch(() => null);
       const data = await res?.json().catch(() => ({}));
-      const parts = data?.candidates?.[0]?.content?.parts || [];
-      const text = parts.map((p: any) => p?.text ?? '').join('').trim();
+      type Part = { text?: string };
+      const parts: Part[] = data?.candidates?.[0]?.content?.parts || [];
+      const text = parts.map((p) => p.text ?? '').join('').trim();
       return text || q;
     }
   } catch {


### PR DESCRIPTION
## Summary
- add rewriteQuery utility to condense natural language queries via OpenAI or Gemini
- rewrite queries before multiSearch and return both the original and rewritten forms
- introduce web search page that displays both user and rewritten queries alongside results

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt prevented completion)*

------
https://chatgpt.com/codex/tasks/task_e_68aed44e5248832f8127b8b1470026a2