### PR TITLE
feat: add quick answer route

### DIFF
--- a/app/api/quick-answer/route.ts
+++ b/app/api/quick-answer/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse } from 'next/server';
 import { multiSearch } from '@/lib/multi-search';
 
+const DISCLAIMER =
+  '⚠️ Informational only — not a substitute for advice from a licensed advocate.';
+
 export async function POST(req: Request) {
-  const { question } = await req.json();
+  const body = await req.json().catch(() => ({}));
+  const question = (body.question ?? body.q ?? '').toString();
 
   // Only ask for a follow-up if nothing was asked
   if (!question || !question.trim()) {
@@ -16,14 +20,15 @@ export async function POST(req: Request) {
   if (message || results.length === 0) {
     return NextResponse.json({
       answer:
-        message || "I couldn't find relevant information. Try rephrasing your question.",
+        (message || "I couldn't find relevant information. Try rephrasing your question.") +
+        `\n\n${DISCLAIMER}`,
       sources: [],
     });
   }
 
   // Use the top result to craft a concise answer
   const top = results[0];
-  const answer = `${top.snippet}\n\nSource: ${top.url}`;
+  const answer = `${top.snippet}\n\nSource: ${top.url}\n\n${DISCLAIMER}`;
 
   return NextResponse.json({
     answer,

--- a/app/api/quick-answer/route.ts
+++ b/app/api/quick-answer/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { multiSearch } from '@/lib/multi-search';
+
+export async function POST(req: Request) {
+  const { question } = await req.json();
+
+  // Only ask for a follow-up if nothing was asked
+  if (!question || !question.trim()) {
+    return NextResponse.json({ answer: 'Please provide a question.' }, { status: 400 });
+  }
+
+  // Quick initial search across Bing/Google/legal DB
+  const { results, message } = await multiSearch(question);
+
+  // If the search produced nothing, fall back to a generic response
+  if (message || results.length === 0) {
+    return NextResponse.json({
+      answer:
+        message || "I couldn't find relevant information. Try rephrasing your question.",
+      sources: [],
+    });
+  }
+
+  // Use the top result to craft a concise answer
+  const top = results[0];
+  const answer = `${top.snippet}\n\nSource: ${top.url}`;
+
+  return NextResponse.json({
+    answer,
+    sources: [top], // Return the first hit as reference
+  });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -13,7 +13,7 @@ body {
 }
 
 .card {
-  @apply bg-white border border-slate-200 rounded-2xl shadow-soft;
+  @apply bg-white border border-slate-200 rounded-2xl shadow-sm;
 }
 
 .btn {


### PR DESCRIPTION
## Summary
- add quick-answer API route that performs a single multi-engine search and returns the top result
- handle empty questions with a 400 response

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68aedc0cc914832f9db789d7f1423720