### PR TITLE
docs: document Gemini environment vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ pnpm dev   # then open http://localhost:3000
 - `AI_PROVIDER` (optional): choose your AI backend (`gemini` or `openai`); defaults to `gemini`.
 - `GEMINI_API_KEY` (optional): required when using Gemini as the provider.
 - `GEMINI_MODEL` (optional): Gemini model to use; defaults to `gemini-1.5-flash`.
-- `OPENAI_API_KEY` (optional): for real answers via OpenAI. Without it you'll see a demo answer with source links.
+- `OPENAI_API_KEY` (optional): required when using OpenAI; otherwise you'll see a demo answer with source links.
+- `OPENAI_MODEL` (optional): OpenAI model to use; defaults to `gpt-4o`.
 
 ## Roadmap hooks (not included yet)
 - Retrieval pipeline (India Code / Gazette / SC / HCs) with hybrid search and RAG
@@ -53,6 +54,7 @@ AI_PROVIDER=gemini
 GEMINI_API_KEY=...
 GEMINI_MODEL=gemini-1.5-flash
 OPENAI_API_KEY=sk-...
+OPENAI_MODEL=gpt-4o
 BING_API_KEY=...
 GOOGLE_API_KEY=...
 GOOGLE_CSE_ID=...

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ pnpm dev   # then open http://localhost:3000
 ```
 
 ## Environment
-- `AI_PROVIDER` (optional): choose your AI backend (`gemini` or `openai`); defaults to `gemini`.
-- `GEMINI_API_KEY` (optional): required when using Gemini as the provider.
-- `GEMINI_MODEL` (optional): Gemini model to use; defaults to `gemini-1.5-flash`.
-- `OPENAI_API_KEY` (optional): required when using OpenAI; otherwise you'll see a demo answer with source links.
-- `OPENAI_MODEL` (optional): OpenAI model to use; defaults to `gpt-4o`.
+- `AI_PROVIDER` (default `gemini`): set to `openai` to use OpenAI instead.
+- `GEMINI_API_KEY`: required when `AI_PROVIDER=gemini`.
+- `GEMINI_MODEL` (optional, default `gemini-1.5-flash`): Gemini model to use.
+- `OPENAI_API_KEY`: required when `AI_PROVIDER=openai`; otherwise you'll see demo answers.
+- `OPENAI_MODEL` (optional, default `gpt-4o`): OpenAI model to use.
 
 ## Roadmap hooks (not included yet)
 - Retrieval pipeline (India Code / Gazette / SC / HCs) with hybrid search and RAG
@@ -50,11 +50,15 @@ pnpm dev   # then open http://localhost:3000
 
 Example `.env.local`:
 ```
+# Gemini (default)
 AI_PROVIDER=gemini
 GEMINI_API_KEY=...
 GEMINI_MODEL=gemini-1.5-flash
-OPENAI_API_KEY=sk-...
-OPENAI_MODEL=gpt-4o
+
+# OpenAI (uncomment to use)
+# AI_PROVIDER=openai
+# OPENAI_API_KEY=sk-...
+# OPENAI_MODEL=gpt-4o
 BING_API_KEY=...
 GOOGLE_API_KEY=...
 GOOGLE_CSE_ID=...

--- a/README.md
+++ b/README.md
@@ -24,11 +24,10 @@ pnpm dev   # then open http://localhost:3000
 ```
 
 ## Environment
-- `AI_PROVIDER` – LLM provider (`gemini` by default; set to `openai` to enable OpenAI).
+- `OPENAI_API_KEY` (optional): for real answers. Without it you'll see a demo answer with source links.
+- `AI_PROVIDER` – LLM provider (`gemini` by default; set to `openai` to use OpenAI).
 - `GEMINI_API_KEY` – required when `AI_PROVIDER=gemini`.
 - `GEMINI_MODEL` – optional, default `gemini-1.5-flash`.
-- `OPENAI_API_KEY` – required when `AI_PROVIDER=openai`; otherwise you'll see demo answers.
-- `OPENAI_MODEL` – optional, default `gpt-4o`.
 
 ## Roadmap hooks (not included yet)
 - Retrieval pipeline (India Code / Gazette / SC / HCs) with hybrid search and RAG
@@ -58,7 +57,6 @@ GEMINI_MODEL=gemini-1.5-flash
 # OpenAI (uncomment to use)
 # AI_PROVIDER=openai
 # OPENAI_API_KEY=sk-...
-# OPENAI_MODEL=gpt-4o
 BING_API_KEY=...
 GOOGLE_API_KEY=...
 GOOGLE_CSE_ID=...

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ pnpm dev   # then open http://localhost:3000
 ```
 
 ## Environment
-- `AI_PROVIDER` (default `gemini`): set to `openai` to use OpenAI instead.
-- `GEMINI_API_KEY`: required when `AI_PROVIDER=gemini`.
-- `GEMINI_MODEL` (optional, default `gemini-1.5-flash`): Gemini model to use.
-- `OPENAI_API_KEY`: required when `AI_PROVIDER=openai`; otherwise you'll see demo answers.
-- `OPENAI_MODEL` (optional, default `gpt-4o`): OpenAI model to use.
+- `AI_PROVIDER` – LLM provider (`gemini` by default; set to `openai` to enable OpenAI).
+- `GEMINI_API_KEY` – required when `AI_PROVIDER=gemini`.
+- `GEMINI_MODEL` – optional, default `gemini-1.5-flash`.
+- `OPENAI_API_KEY` – required when `AI_PROVIDER=openai`; otherwise you'll see demo answers.
+- `OPENAI_MODEL` – optional, default `gpt-4o`.
 
 ## Roadmap hooks (not included yet)
 - Retrieval pipeline (India Code / Gazette / SC / HCs) with hybrid search and RAG

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ pnpm dev   # then open http://localhost:3000
 ```
 
 ## Environment
-- `OPENAI_API_KEY` (optional): for real answers. Without it you'll see a demo answer with source links.
 - `AI_PROVIDER` – LLM provider (`gemini` by default; set to `openai` to use OpenAI).
+- `OPENAI_API_KEY` – required when `AI_PROVIDER=openai`; otherwise you'll see demo answers with source links.
+- `OPENAI_MODEL` – optional, default `gpt-4o`.
 - `GEMINI_API_KEY` – required when `AI_PROVIDER=gemini`.
 - `GEMINI_MODEL` – optional, default `gemini-1.5-flash`.
 
@@ -57,6 +58,7 @@ GEMINI_MODEL=gemini-1.5-flash
 # OpenAI (uncomment to use)
 # AI_PROVIDER=openai
 # OPENAI_API_KEY=sk-...
+# OPENAI_MODEL=gpt-4o
 BING_API_KEY=...
 GOOGLE_API_KEY=...
 GOOGLE_CSE_ID=...

--- a/README.md
+++ b/README.md
@@ -24,11 +24,10 @@ pnpm dev   # then open http://localhost:3000
 ```
 
 ## Environment
-- `AI_PROVIDER` – LLM provider (`gemini` by default; set to `openai` to use OpenAI).
+- `AI_PROVIDER` – LLM provider (`gemini` by default; use `openai` for OpenAI).
 - `GEMINI_API_KEY` – required when `AI_PROVIDER=gemini`.
 - `GEMINI_MODEL` – optional, default `gemini-1.5-flash`.
 - `OPENAI_API_KEY` – required when `AI_PROVIDER=openai`; otherwise you'll see demo answers with source links.
-- `OPENAI_MODEL` – optional, default `gpt-4o`.
 
 ## Roadmap hooks (not included yet)
 - Retrieval pipeline (India Code / Gazette / SC / HCs) with hybrid search and RAG
@@ -58,7 +57,6 @@ GEMINI_MODEL=gemini-1.5-flash
 # OpenAI (uncomment to use)
 # AI_PROVIDER=openai
 # OPENAI_API_KEY=sk-...
-# OPENAI_MODEL=gpt-4o
 BING_API_KEY=...
 GOOGLE_API_KEY=...
 GOOGLE_CSE_ID=...

--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ A simple, elegant, ChatGPT-style legal search interface with **New chat**, **Sea
 ```bash
 pnpm i     # or npm i or yarn
 cp .env.local.example .env.local
-# (optional) edit .env.local and add OPENAI_API_KEY=sk-...
+# (optional) edit .env.local to set AI_PROVIDER and API key(s)
 
 pnpm dev   # then open http://localhost:3000
 ```
 
 ## Environment
 - `AI_PROVIDER` – LLM provider (`gemini` by default; set to `openai` to use OpenAI).
-- `OPENAI_API_KEY` – required when `AI_PROVIDER=openai`; otherwise you'll see demo answers with source links.
-- `OPENAI_MODEL` – optional, default `gpt-4o`.
 - `GEMINI_API_KEY` – required when `AI_PROVIDER=gemini`.
 - `GEMINI_MODEL` – optional, default `gemini-1.5-flash`.
+- `OPENAI_API_KEY` – required when `AI_PROVIDER=openai`; otherwise you'll see demo answers with source links.
+- `OPENAI_MODEL` – optional, default `gpt-4o`.
 
 ## Roadmap hooks (not included yet)
 - Retrieval pipeline (India Code / Gazette / SC / HCs) with hybrid search and RAG

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ pnpm dev   # then open http://localhost:3000
 ```
 
 ## Environment
-- `OPENAI_API_KEY` (optional): for real answers. Without it you'll see a demo answer with source links.
+- `AI_PROVIDER` (optional): choose your AI backend (`gemini` or `openai`); defaults to `gemini`.
+- `GEMINI_API_KEY` (optional): required when using Gemini as the provider.
+- `GEMINI_MODEL` (optional): Gemini model to use; defaults to `gemini-1.5-flash`.
+- `OPENAI_API_KEY` (optional): for real answers via OpenAI. Without it you'll see a demo answer with source links.
 
 ## Roadmap hooks (not included yet)
 - Retrieval pipeline (India Code / Gazette / SC / HCs) with hybrid search and RAG
@@ -46,6 +49,9 @@ pnpm dev   # then open http://localhost:3000
 
 Example `.env.local`:
 ```
+AI_PROVIDER=gemini
+GEMINI_API_KEY=...
+GEMINI_MODEL=gemini-1.5-flash
 OPENAI_API_KEY=sk-...
 BING_API_KEY=...
 GOOGLE_API_KEY=...


### PR DESCRIPTION
## Summary
- document AI_PROVIDER, GEMINI_API_KEY, and GEMINI_MODEL usage in README
- expand example .env snippet with Gemini variables

## Testing
- `pnpm lint` *(fails: prompts to configure ESLint)*
- `pnpm test` *(fails: no test script, unsupported engine warning)*

------
https://chatgpt.com/codex/tasks/task_e_68aee2f8384c832fb50cc7d089441d9d