### PR TITLE
Fix invalid tailwind class reference

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,7 +13,8 @@ body {
 }
 
 .card {
-  @apply bg-white border border-slate-200 rounded-2xl shadow-soft;
+  /* Use the custom card shadow defined in tailwind.config.ts */
+  @apply bg-white border border-slate-200 rounded-2xl shadow-card;
 }
 
 .btn {


### PR DESCRIPTION
## Summary
- use `shadow-card` instead of undefined `shadow-soft` in globals CSS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompting for ESLint setup)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aef50006a0832fb94a86e5ffef2c70